### PR TITLE
MAINT: Fix for upcoming bump in scipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,14 @@ python:
 env:
     - PYSAL_PYPI=true PYSAL_PLUS=true
     - PYSAL_PYPI=true PYSAL_PLUS=false
-    - PYSAL_PYPI=false PYSAL_PLUS=true
-    - PYSAL_PYPI=false PYSAL_PLUS=false
 
 
 matrix:
   allow_failures:
     - python: 3.6
       env: PYSAL_PYPI=false PYSAL_PLUS=false
-    - python: 3.6
-      env: PYSAL_PYPI=false PYSAL_PLUS=true
     - python: 3.7
       env: PYSAL_PYPI=false PYSAL_PLUS=false
-    - python: 3.7
-      env: PYSAL_PYPI=false PYSAL_PLUS=true
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,32 @@
+dist: xenial
 language: python
-sudo: false
+sudo: true
 branches:
-only:
-  - master
+  only:
+    - master
+
+python:
+  - 3.6
+  - 3.7
+
+env:
+    - PYSAL_PYPI=true PYSAL_PLUS=true
+    - PYSAL_PYPI=true PYSAL_PLUS=false
+    - PYSAL_PYPI=false PYSAL_PLUS=true
+    - PYSAL_PYPI=false PYSAL_PLUS=false
+
 
 matrix:
-  include:
+  allow_failures:
     - python: 3.6
-      env: PYSAL_PLUS=false
+      env: PYSAL_PYPI=false PYSAL_PLUS=false
     - python: 3.6
-      env: PYSAL_PLUS=true
+      env: PYSAL_PYPI=false PYSAL_PLUS=true
     - python: 3.7
-      dist: xenial
-      sudo: true
-      env: PYSAL_PLUS=false
+      env: PYSAL_PYPI=false PYSAL_PLUS=false
     - python: 3.7
-      dist: xenial
-      sudo: true
-      env: PYSAL_PLUS=true
+      env: PYSAL_PYPI=false PYSAL_PLUS=true
+
 
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: true
 branches:
   only:
     - master
+    - /.*/
 
 python:
   - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,7 @@ notifications:
             - dfolch@gmail.com
             - daniel.arribas.bel@gmail.com
             - weikang9009@gmail.com
-            - carsonfarmer@gmail.com
             - tayoshan@gmail.com
-            - marynia.kolak@gmail.com
             - jgaboardi@gmail.com
             - phil.stphns@gmail.com
             - pedrovma@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       env: PYSAL_PLUS=true
 
 before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,21 @@ sudo: false
 branches:
 only:
   - master
-python:
-    - 3.5
-    - 3.6
-env: 
-    - PYSAL_PYPI=true
-    - PYSAL_PYPI=false
+
 matrix:
-  allow_failures:
-      - python: 3.5
-        env: PYSAL_PYPI=false
-      - python: 3.6
-        env: PYSAL_PYPI=false
-      - python: 3.7
-        env: PYSAL_PYPI=false
+  include:
+    - python: 3.6
+      env: PYSAL_PLUS=false
+    - python: 3.6
+      env: PYSAL_PLUS=true
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: PYSAL_PLUS=false
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: PYSAL_PLUS=true
 
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,8 @@ def setup_package():
             'Topic :: Scientific/Engineering :: GIS',
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6'
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7'
         ],
         # package_data={'libpysal':list(example_data_files)},
           install_requires=install_reqs,

--- a/spreg/diagnostics_tsls.py
+++ b/spreg/diagnostics_tsls.py
@@ -215,12 +215,12 @@ def pr2_aspatial(tslsreg):
     y = tslsreg.y
     predy = tslsreg.predy
     n,k = y.shape
-    y.shape =(n,)
-    predy.shape=(n,)
+    y.shape = (n,)
+    predy.shape = (n,)
     pr = pearsonr(y, predy)[0]
     pr2_result = float(pr ** 2)
-    y.shape =(n,1)
-    predy.shape=(n,1)
+    y.shape = (n,1)
+    predy.shape = (n,1)
     return pr2_result
 
 
@@ -328,12 +328,12 @@ def pr2_spatial(tslsreg):
     y = tslsreg.y
     predy_e = tslsreg.predy_e
     n,k = y.shape
-    y.shape =(n,)
+    y.shape = (n,)
     predy_e.shape=(n,)
     pr = pearsonr(y, predy_e)[0]
     pr2_result = float(pr ** 2)
-    y.shape =(n,1)
-    predy_e.shape=(n,1)
+    y.shape = (n,1)
+    predy_e.shape = (n,1)
     return pr2_result
 
 

--- a/spreg/diagnostics_tsls.py
+++ b/spreg/diagnostics_tsls.py
@@ -214,8 +214,13 @@ def pr2_aspatial(tslsreg):
 
     y = tslsreg.y
     predy = tslsreg.predy
+    n,k = y.shape
+    y.shape =(n,)
+    predy.shape=(n,)
     pr = pearsonr(y, predy)[0]
     pr2_result = float(pr ** 2)
+    y.shape =(n,1)
+    predy.shape=(n,1)
     return pr2_result
 
 
@@ -322,8 +327,13 @@ def pr2_spatial(tslsreg):
 
     y = tslsreg.y
     predy_e = tslsreg.predy_e
+    n,k = y.shape
+    y.shape =(n,)
+    predy_e.shape=(n,)
     pr = pearsonr(y, predy_e)[0]
     pr2_result = float(pr ** 2)
+    y.shape =(n,1)
+    predy_e.shape=(n,1)
     return pr2_result
 
 


### PR DESCRIPTION
This adds a fix for breakage that will occur when moving from scipy 1.2.1 to 1.3.0.

[pysal-meta](https://github.com/pysal/pysal/issues/1100#issuecomment-495940208) has encountered these breaks  downstream.

It also drops 3.5 support following the decision to do so in the meta-package.