### PR TITLE
use flatten instead of setting shape directly

### DIFF
--- a/spreg/diagnostics_tsls.py
+++ b/spreg/diagnostics_tsls.py
@@ -213,13 +213,8 @@ def pr2_aspatial(tslsreg):
 
     y = tslsreg.y
     predy = tslsreg.predy
-    n,k = y.shape
-    y.shape = (n,)
-    predy.shape = (n,)
-    pr = pearsonr(y, predy)[0]
+    pr = pearsonr(y.flatten(), predy.flatten())[0]
     pr2_result = float(pr ** 2)
-    y.shape = (n,1)
-    predy.shape = (n,1)
     return pr2_result
 
 
@@ -326,13 +321,8 @@ def pr2_spatial(tslsreg):
 
     y = tslsreg.y
     predy_e = tslsreg.predy_e
-    n,k = y.shape
-    y.shape = (n,)
-    predy_e.shape=(n,)
-    pr = pearsonr(y, predy_e)[0]
+    pr = pearsonr(y.flatten(), predy_e.flatten())[0]
     pr2_result = float(pr ** 2)
-    y.shape = (n,1)
-    predy_e.shape = (n,1)
     return pr2_result
 
 


### PR DESCRIPTION
this resolves #33 by using `flatten()` instead of setting and re-setting the array's `shape` param