### PR TITLE
Updates on all spreg functions

### DIFF
--- a/spreg/error_sp.py
+++ b/spreg/error_sp.py
@@ -285,12 +285,13 @@ class GM_Error(BaseGM_Error):
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseGM_Error.__init__(self, y=y, x=x_constant, w=w.sparse)
         self.title = "SPATIALLY WEIGHTED LEAST SQUARES"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_x.append('lambda')
         self.name_w = USER.set_name_w(name_w, w)
         SUMMARY.GM_Error(reg=self, w=w, vm=vm)
@@ -611,13 +612,14 @@ class GM_Endog_Error(BaseGM_Endog_Error):
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseGM_Endog_Error.__init__(
             self, y=y, x=x_constant, w=w.sparse, yend=yend, q=q)
         self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_z = self.name_x + self.name_yend
         self.name_z.append('lambda')
@@ -997,8 +999,9 @@ class GM_Combo(BaseGM_Combo):
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        yend2, q2 = set_endog(y, x, w, yend, q, w_lags, lag_q)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
+        yend2, q2 = set_endog(y, x_constant[:,1:], w, yend, q, w_lags, lag_q)
         BaseGM_Combo.__init__(
             self, y=y, x=x_constant, w=w.sparse, yend=yend2, q=q2,
             w_lags=w_lags, lag_q=lag_q)
@@ -1009,7 +1012,7 @@ class GM_Combo(BaseGM_Combo):
         self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_yend.append(USER.set_name_yend_sp(self.name_y))
         self.name_z = self.name_x + self.name_yend

--- a/spreg/error_sp.py
+++ b/spreg/error_sp.py
@@ -283,7 +283,7 @@ class GM_Error(BaseGM_Error):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant = USER.check_constant(x)
         BaseGM_Error.__init__(self, y=y, x=x_constant, w=w.sparse)
@@ -609,7 +609,7 @@ class GM_Endog_Error(BaseGM_Endog_Error):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant = USER.check_constant(x)
         BaseGM_Endog_Error.__init__(
@@ -995,7 +995,7 @@ class GM_Combo(BaseGM_Combo):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         yend2, q2 = set_endog(y, x, w, yend, q, w_lags, lag_q)
         x_constant = USER.check_constant(x)

--- a/spreg/error_sp_het.py
+++ b/spreg/error_sp_het.py
@@ -336,14 +336,15 @@ class GM_Error_Het(BaseGM_Error_Het):
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseGM_Error_Het.__init__(
             self, y, x_constant, w.sparse, max_iter=max_iter,
             step1c=step1c, epsilon=epsilon)
         self.title = "SPATIALLY WEIGHTED LEAST SQUARES (HET)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_x.append('lambda')
         self.name_w = USER.set_name_w(name_w, w)
         SUMMARY.GM_Error_Het(reg=self, w=w, vm=vm)
@@ -749,14 +750,15 @@ class GM_Endog_Error_Het(BaseGM_Endog_Error_Het):
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseGM_Endog_Error_Het.__init__(self, y=y, x=x_constant, yend=yend,
                                         q=q, w=w.sparse, max_iter=max_iter,
                                         step1c=step1c, epsilon=epsilon, inv_method=inv_method)
         self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES (HET)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_z = self.name_x + self.name_yend
         self.name_z.append('lambda')  # listing lambda last
@@ -1174,8 +1176,9 @@ class GM_Combo_Het(BaseGM_Combo_Het):
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        yend2, q2 = set_endog(y, x, w, yend, q, w_lags, lag_q)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
+        yend2, q2 = set_endog(y, x_constant[:,1:], w, yend, q, w_lags, lag_q)
         BaseGM_Combo_Het.__init__(self, y=y, x=x_constant, yend=yend2, q=q2,
                                   w=w.sparse, w_lags=w_lags,
                                   max_iter=max_iter, step1c=step1c, lag_q=lag_q,
@@ -1187,7 +1190,7 @@ class GM_Combo_Het(BaseGM_Combo_Het):
         self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES (HET)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_yend.append(USER.set_name_yend_sp(self.name_y))
         self.name_z = self.name_x + self.name_yend

--- a/spreg/error_sp_het.py
+++ b/spreg/error_sp_het.py
@@ -15,7 +15,7 @@ from . import user_output as USER
 from . import summary_output as SUMMARY
 from . import twosls as TSLS
 from . import utils as UTILS
-from .utils import RegressionPropsY, spdot, set_endog, sphstack
+from .utils import RegressionPropsY, spdot, set_endog, sphstack, set_warn
 from scipy import sparse as SP
 from libpysal.weights.spatial_lag import lag_spatial
 

--- a/spreg/error_sp_het.py
+++ b/spreg/error_sp_het.py
@@ -334,7 +334,7 @@ class GM_Error_Het(BaseGM_Error_Het):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant = USER.check_constant(x)
         BaseGM_Error_Het.__init__(
@@ -747,7 +747,7 @@ class GM_Endog_Error_Het(BaseGM_Endog_Error_Het):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant = USER.check_constant(x)
         BaseGM_Endog_Error_Het.__init__(self, y=y, x=x_constant, yend=yend,
@@ -1172,7 +1172,7 @@ class GM_Combo_Het(BaseGM_Combo_Het):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         yend2, q2 = set_endog(y, x, w, yend, q, w_lags, lag_q)
         x_constant = USER.check_constant(x)

--- a/spreg/error_sp_het_regimes.py
+++ b/spreg/error_sp_het_regimes.py
@@ -319,6 +319,8 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             else:
                 raise Exception("All coefficients must vary accross regimes if regime_err_sep = True.")
         else:
+            x_constant = sphstack(np.ones((x_constant.shape[0], 1)), x_constant)
+            name_x = USER.set_name_x(name_x, x_constant)
             self.x, self.name_x = REGI.Regimes_Frame.__init__(self, x_constant,
                                                               regimes, constant_regi=None, cols2regi=cols2regi, names=name_x)
             ols = BaseOLS(y=y, x=self.x)
@@ -811,6 +813,8 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             else:
                 raise Exception("All coefficients must vary accross regimes if regime_err_sep = True.")
         else:
+            x_constant = sphstack(np.ones((x_constant.shape[0], 1)), x_constant)
+            name_x = USER.set_name_x(name_x, x_constant)
             q, name_q = REGI.Regimes_Frame.__init__(self, q,
                                                     regimes, constant_regi=None, cols2regi='all', names=name_q)
             x, name_x = REGI.Regimes_Frame.__init__(self, x_constant,
@@ -912,7 +916,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 is_win = False
         """
         x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
-        self.name_x_r = name_x
+        self.name_x_r = name_x + name_yend
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
@@ -1383,7 +1387,7 @@ class GM_Combo_Het_Regimes(GM_Endog_Error_Het_Regimes):
             add_lag = False
             if regime_err_sep == True:
                 raise Exception("For spatial combo models, if spatial error is set by regimes (regime_err_sep=True), all coefficients including lambda (regime_lag_sep=True) must be set by regimes.")
-            yend, q = set_endog(y, x_constant[:,1:], w, yend, q, w_lags, lag_q)
+            yend, q = set_endog(y, x_constant, w, yend, q, w_lags, lag_q)
         name_yend.append(USER.set_name_yend_sp(self.name_y))
 
         GM_Endog_Error_Het_Regimes.__init__(self, y=y, x=x_constant, yend=yend,

--- a/spreg/error_sp_het_regimes.py
+++ b/spreg/error_sp_het_regimes.py
@@ -288,7 +288,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                  name_ds=None, name_regimes=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
@@ -773,7 +773,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                  name_regimes=None, summ=True, add_lag=False):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
@@ -1346,7 +1346,7 @@ class GM_Combo_Het_Regimes(GM_Endog_Error_Het_Regimes):
 
         n = USER.check_arrays(y, x)
         self.step1c = step1c
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         name_x = USER.set_name_x(name_x, x, constant=True)
         self.name_y = USER.set_name_y(name_y)

--- a/spreg/error_sp_hom.py
+++ b/spreg/error_sp_hom.py
@@ -344,7 +344,7 @@ class GM_Error_Hom(BaseGM_Error_Hom):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant = USER.check_constant(x)
         BaseGM_Error_Hom.__init__(self, y=y, x=x_constant, w=w.sparse, A1=A1,
@@ -749,7 +749,7 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant = USER.check_constant(x)
         BaseGM_Endog_Error_Hom.__init__(
@@ -1172,7 +1172,7 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
                  name_w=None, name_ds=None):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         yend2, q2 = set_endog(y, x, w, yend, q, w_lags, lag_q)
         x_constant = USER.check_constant(x)

--- a/spreg/error_sp_hom.py
+++ b/spreg/error_sp_hom.py
@@ -346,13 +346,14 @@ class GM_Error_Hom(BaseGM_Error_Hom):
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseGM_Error_Hom.__init__(self, y=y, x=x_constant, w=w.sparse, A1=A1,
                                   max_iter=max_iter, epsilon=epsilon)
         self.title = "SPATIALLY WEIGHTED LEAST SQUARES (HOM)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_x.append('lambda')
         self.name_w = USER.set_name_w(name_w, w)
         SUMMARY.GM_Error_Hom(reg=self, w=w, vm=vm)
@@ -751,14 +752,15 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseGM_Endog_Error_Hom.__init__(
             self, y=y, x=x_constant, w=w.sparse, yend=yend, q=q,
             A1=A1, max_iter=max_iter, epsilon=epsilon)
         self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES (HOM)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_z = self.name_x + self.name_yend
         self.name_z.append('lambda')  # listing lambda last
@@ -1174,8 +1176,9 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        yend2, q2 = set_endog(y, x, w, yend, q, w_lags, lag_q)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
+        yend2, q2 = set_endog(y, x_constant[:,1:], w, yend, q, w_lags, lag_q)
         BaseGM_Combo_Hom.__init__(
             self, y=y, x=x_constant, w=w.sparse, yend=yend2, q=q2,
             w_lags=w_lags, A1=A1, lag_q=lag_q,
@@ -1187,7 +1190,7 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
         self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES (HOM)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_yend.append(USER.set_name_yend_sp(self.name_y))
         self.name_z = self.name_x + self.name_yend

--- a/spreg/error_sp_hom_regimes.py
+++ b/spreg/error_sp_hom_regimes.py
@@ -303,7 +303,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                  name_w=None, name_ds=None, name_regimes=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
@@ -791,7 +791,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                  name_ds=None, name_regimes=None, summ=True, add_lag=False):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
@@ -1363,7 +1363,7 @@ class GM_Combo_Hom_Regimes(GM_Endog_Error_Hom_Regimes):
                  name_w=None, name_ds=None, name_regimes=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         name_x = USER.set_name_x(name_x, x, constant=True)
         self.name_y = USER.set_name_y(name_y)

--- a/spreg/error_sp_hom_regimes.py
+++ b/spreg/error_sp_hom_regimes.py
@@ -404,7 +404,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         """
         x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
         self.name_x_r = name_x
-         for r in self.regimes_set:
+        for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work_error, args=(

--- a/spreg/error_sp_hom_regimes.py
+++ b/spreg/error_sp_hom_regimes.py
@@ -315,19 +315,20 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         self.n = n
         self.y = y
 
-        x_constant = USER.check_constant(x)
-        name_x = USER.set_name_x(name_x, x)
-        self.name_x_r = name_x
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
+        self.name_x_r = USER.set_name_x(name_x, x_constant)
 
-        cols2regi = REGI.check_cols2regi(constant_regi, cols2regi, x)
+
+        cols2regi = REGI.check_cols2regi(constant_regi, cols2regi, x_constant)
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, self.n, x.shape[1])
+        USER.check_regimes(self.regimes_set, self.n, x_constant.shape[1])
         self.regime_err_sep = regime_err_sep
 
         if regime_err_sep == True:
             if set(cols2regi) == set([True]):
-                self._error_regimes_multi(y, x, regimes, w, cores,
+                self._error_regimes_multi(y, x_constant, regimes, w, cores,
                                           max_iter, epsilon, A1, cols2regi, vm, name_x)
             else:
                 raise Exception("All coefficients must vary accross regimes if regime_err_sep = True.")
@@ -401,14 +402,16 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 results_p[r] = pool.apply_async(_work_error,args=(y,x,regi_ids,r,w,max_iter,epsilon,A1,self.name_ds,self.name_y,name_x+['lambda'],self.name_w,self.name_regimes, ))
                 is_win = False
         """
-        for r in self.regimes_set:
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        self.name_x_r = name_x
+         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work_error, args=(
-                    y, x, regi_ids, r, w, max_iter, epsilon, A1, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes, ))
+                    y, x_constant, regi_ids, r, w, max_iter, epsilon, A1, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes, ))
             else:
                 results_p[r] = _work_error(
-                    *(y, x, regi_ids, r, w, max_iter, epsilon, A1, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes))
+                    *(y, x_constant, regi_ids, r, w, max_iter, epsilon, A1, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes))
 
         self.kryd = 0
         self.kr = len(cols2regi) + 1
@@ -801,23 +804,26 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         self.n = n
         self.y = y
 
-        name_x = USER.set_name_x(name_x, x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
+
         if summ:
             name_yend = USER.set_name_yend(name_yend, yend)
             self.name_y = USER.set_name_y(name_y)
             name_q = USER.set_name_q(name_q, q)
-        self.name_x_r = name_x + name_yend
+        self.name_x_r = USER.set_name_x(name_x, x_constant) + name_yend
 
         cols2regi = REGI.check_cols2regi(
-            constant_regi, cols2regi, x, yend=yend)
+            constant_regi, cols2regi, x_constant, yend=yend)
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, self.n, x.shape[1])
+        USER.check_regimes(self.regimes_set, self.n, x_constant.shape[1])
         self.regime_err_sep = regime_err_sep
 
         if regime_err_sep == True:
             if set(cols2regi) == set([True]):
-                self._endog_error_regimes_multi(y, x, regimes, w, yend, q, cores,
+                self._endog_error_regimes_multi(y, x_constant, regimes, w, yend, q, cores,
                                                 max_iter, epsilon, A1, cols2regi, vm,
                                                 name_x, name_yend, name_q, add_lag)
             else:
@@ -919,13 +925,15 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 results_p[r] = pool.apply_async(_work_endog_error,args=(y,x,yend,q,regi_ids,r,w,max_iter,epsilon,A1,self.name_ds,self.name_y,name_x,name_yend,name_q,self.name_w,self.name_regimes,add_lag, ))
                 is_win = False
         """
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        self.name_x_r = name_x
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work_endog_error, args=(
-                    y, x, yend, q, regi_ids, r, w, max_iter, epsilon, A1, self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes, add_lag, ))
+                    y, x_constant, yend, q, regi_ids, r, w, max_iter, epsilon, A1, self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes, add_lag, ))
             else:
-                results_p[r] = _work_endog_error(*(y, x, yend, q, regi_ids, r, w, max_iter, epsilon, A1,
+                results_p[r] = _work_endog_error(*(y, x_constant, yend, q, regi_ids, r, w, max_iter, epsilon, A1,
                                                    self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes, add_lag))
 
         self.kryd, self.kf = 0, 0
@@ -1365,7 +1373,9 @@ class GM_Combo_Hom_Regimes(GM_Endog_Error_Hom_Regimes):
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        name_x = USER.set_name_x(name_x, x, constant=True)
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
         self.name_y = USER.set_name_y(name_y)
         name_yend = USER.set_name_yend(name_yend, yend)
         name_q = USER.set_name_q(name_q, q)
@@ -1373,10 +1383,10 @@ class GM_Combo_Hom_Regimes(GM_Endog_Error_Hom_Regimes):
             USER.set_name_q_sp(name_x, w_lags, name_q, lag_q, force_all=True))
 
         cols2regi = REGI.check_cols2regi(
-            constant_regi, cols2regi, x, yend=yend, add_cons=False)
+            constant_regi, cols2regi, x_constant, yend=yend, add_cons=False)
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, n, x.shape[1])
+        USER.check_regimes(self.regimes_set, n, x_constant.shape[1])
         self.regime_err_sep = regime_err_sep
         self.regime_lag_sep = regime_lag_sep
 
@@ -1389,10 +1399,10 @@ class GM_Combo_Hom_Regimes(GM_Endog_Error_Hom_Regimes):
             add_lag = False
             if regime_err_sep == True:
                 raise Exception("For spatial combo models, if spatial error is set by regimes (regime_err_sep=True), all coefficients including lambda (regime_lag_sep=True) must be set by regimes.")
-            yend, q = set_endog(y, x, w, yend, q, w_lags, lag_q)
+            yend, q = set_endog(y, x_constant[:,1:], w, yend, q, w_lags, lag_q)
         name_yend.append(USER.set_name_yend_sp(self.name_y))
 
-        GM_Endog_Error_Hom_Regimes.__init__(self, y=y, x=x, yend=yend,
+        GM_Endog_Error_Hom_Regimes.__init__(self, y=y, x=x_constant, yend=yend,
                                             q=q, regimes=regimes, w=w, vm=vm, constant_regi=constant_regi,
                                             cols2regi=cols2regi, regime_err_sep=regime_err_sep,
                                             max_iter=max_iter, epsilon=epsilon, A1=A1, cores=cores,
@@ -1414,9 +1424,8 @@ def _work_error(y, x, regi_ids, r, w, max_iter, epsilon, A1, name_ds, name_y, na
     w_r, warn = REGI.w_regime(w, regi_ids[r], r, transform=True)
     y_r = y[regi_ids[r]]
     x_r = x[regi_ids[r]]
-    x_constant = USER.check_constant(x_r)
     model = BaseGM_Error_Hom(
-        y_r, x_constant, w_r.sparse, max_iter=max_iter, epsilon=epsilon, A1=A1)
+        y_r, x_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, A1=A1)
     set_warn(model, warn)
     model.w = w_r
     model.title = "SPATIALLY WEIGHTED LEAST SQUARES ESTIMATION (HOM) - REGIME %s" % r
@@ -1439,10 +1448,10 @@ def _work_endog_error(y, x, yend, q, regi_ids, r, w, max_iter, epsilon, A1, name
         yend_r, q_r = None, None
     if add_lag != False:
         yend_r, q_r = set_endog(
-            y_r, x_r, w_r, yend_r, q_r, add_lag[0], add_lag[1])
+            y_r, x_r[:,1:], w_r, yend_r, q_r, add_lag[0], add_lag[1])
     x_constant = USER.check_constant(x_r)
     model = BaseGM_Endog_Error_Hom(
-        y_r, x_constant, yend_r, q_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, A1=A1)
+        y_r, x_r, yend_r, q_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, A1=A1)
     set_warn(model, warn)
     if add_lag != False:
         model.rho = model.betas[-2]

--- a/spreg/error_sp_regimes.py
+++ b/spreg/error_sp_regimes.py
@@ -283,6 +283,11 @@ class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
+        self.name_x_r = USER.set_name_x(name_x, x_constant)
+
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
         self.name_ds = USER.set_name_ds(name_ds)
@@ -292,18 +297,14 @@ class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         self.n = n
         self.y = y
 
-        x_constant = USER.check_constant(x)
-        name_x = USER.set_name_x(name_x, x)
-        self.name_x_r = name_x
-
-        cols2regi = REGI.check_cols2regi(constant_regi, cols2regi, x)
+        cols2regi = REGI.check_cols2regi(constant_regi, cols2regi, x_constant)
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, self.n, x.shape[1])
+        USER.check_regimes(self.regimes_set, self.n, x_constant.shape[1])
         self.regime_err_sep = regime_err_sep
         if regime_err_sep == True:
             if set(cols2regi) == set([True]):
-                self._error_regimes_multi(y, x, regimes, w, cores,
+                self._error_regimes_multi(y, x_constant, regimes, w, cores,
                                           cols2regi, vm, name_x)
             else:
                 raise Exception("All coefficients must vary accross regimes if regime_err_sep = True.")
@@ -349,14 +350,16 @@ class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 results_p[r] = pool.apply_async(_work_error,args=(y,x,regi_ids,r,w,self.name_ds,self.name_y,name_x+['lambda'],self.name_w,self.name_regimes, ))
                 is_win = False
         """
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        self.name_x_r = name_x
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work_error, args=(
-                    y, x, regi_ids, r, w, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes, ))
+                    y, x_constant, regi_ids, r, w, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes, ))
             else:
                 results_p[r] = _work_error(
-                    *(y, x, regi_ids, r, w, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes))
+                    *(y, x_constant, regi_ids, r, w, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes))
 
         self.kryd = 0
         self.kr = len(cols2regi)
@@ -707,6 +710,9 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
         self.name_ds = USER.set_name_ds(name_ds)
@@ -715,28 +721,26 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         self.n = n
         self.y = y
 
-        name_x = USER.set_name_x(name_x, x)
         if summ:
             name_yend = USER.set_name_yend(name_yend, yend)
             self.name_y = USER.set_name_y(name_y)
             name_q = USER.set_name_q(name_q, q)
-        self.name_x_r = name_x + name_yend
+        self.name_x_r = USER.set_name_x(name_x, x_constant) + name_yend
 
         cols2regi = REGI.check_cols2regi(
-            constant_regi, cols2regi, x, yend=yend)
+            constant_regi, cols2regi, x_constant, yend=yend)
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, self.n, x.shape[1])
+        USER.check_regimes(self.regimes_set, self.n, x_constant.shape[1])
         self.regime_err_sep = regime_err_sep
 
         if regime_err_sep == True:
             if set(cols2regi) == set([True]):
-                self._endog_error_regimes_multi(y, x, regimes, w, yend, q, cores,
+                self._endog_error_regimes_multi(y, x_constant, regimes, w, yend, q, cores,
                                                 cols2regi, vm, name_x, name_yend, name_q, add_lag)
             else:
                 raise Exception("All coefficients must vary accross regimes if regime_err_sep = True.")
         else:
-            x_constant = USER.check_constant(x)
             q, name_q = REGI.Regimes_Frame.__init__(self, q,
                                                     regimes, constant_regi=None, cols2regi='all', names=name_q)
             x, name_x = REGI.Regimes_Frame.__init__(self, x_constant,
@@ -769,7 +773,7 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             self.sig2 = float(np.dot(tsls2.u.T, tsls2.u)) / self.n
             self.e_filtered = self.u - lambda1 * lag_spatial(w, self.u)
             self.vm = self.sig2 * tsls2.varb
-            self.name_x = USER.set_name_x(name_x, x, constant=True)
+            self.name_x = USER.set_name_x(name_x, x_constant, constant=True)
             self.name_yend = USER.set_name_yend(name_yend, yend)
             self.name_z = self.name_x + self.name_yend
             self.name_z.append('lambda')
@@ -793,8 +797,8 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             self.predy_e = np.zeros((self.n, 1), float)
             self.e_pred = np.zeros((self.n, 1), float)
         results_p = {}
+        """
         for r in self.regimes_set:
-            """
             if system() == 'Windows':
                 results_p[r] = _work_endog_error(*(y,x,yend,q,regi_ids,r,w,self.name_ds,self.name_y,name_x,name_yend,name_q,self.name_w,self.name_regimes,add_lag))
                 is_win = True
@@ -802,15 +806,17 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 pool = mp.Pool(cores)        
                 results_p[r] = pool.apply_async(_work_endog_error,args=(y,x,yend,q,regi_ids,r,w,self.name_ds,self.name_y,name_x,name_yend,name_q,self.name_w,self.name_regimes,add_lag, ))
                 is_win = False
-            """
+        """
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        self.name_x_r = name_x
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work_endog_error, args=(
-                    y, x, yend, q, regi_ids, r, w, self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes, add_lag, ))
+                    y, x_constant, yend, q, regi_ids, r, w, self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes, add_lag, ))
             else:
                 results_p[r] = _work_endog_error(
-                    *(y, x, yend, q, regi_ids, r, w, self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes, add_lag))
+                    *(y, x_constant, yend, q, regi_ids, r, w, self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes, add_lag))
 
         self.kryd, self.kf = 0, 0
         self.kr = len(cols2regi)
@@ -1225,7 +1231,9 @@ class GM_Combo_Regimes(GM_Endog_Error_Regimes, REGI.Regimes_Frame):
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        name_x = USER.set_name_x(name_x, x, constant=True)
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
         self.name_y = USER.set_name_y(name_y)
         name_yend = USER.set_name_yend(name_yend, yend)
         name_q = USER.set_name_q(name_q, q)
@@ -1233,10 +1241,10 @@ class GM_Combo_Regimes(GM_Endog_Error_Regimes, REGI.Regimes_Frame):
             USER.set_name_q_sp(name_x, w_lags, name_q, lag_q, force_all=True))
 
         cols2regi = REGI.check_cols2regi(
-            constant_regi, cols2regi, x, yend=yend, add_cons=False)
+            constant_regi, cols2regi, x_constant, yend=yend, add_cons=False)
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, n, x.shape[1])
+        USER.check_regimes(self.regimes_set, n, x_constant.shape[1])
         self.regime_err_sep = regime_err_sep
         self.regime_lag_sep = regime_lag_sep
 
@@ -1249,10 +1257,10 @@ class GM_Combo_Regimes(GM_Endog_Error_Regimes, REGI.Regimes_Frame):
                 raise Exception("For spatial combo models, if spatial error is set by regimes (regime_err_sep=True), all coefficients including lambda (regime_lag_sep=True) must be set by regimes.")
             cols2regi += [False]
             add_lag = False
-            yend, q = set_endog(y, x, w, yend, q, w_lags, lag_q)
+            yend, q = set_endog(y, x_constant[:,1:], w, yend, q, w_lags, lag_q)
         name_yend.append(USER.set_name_yend_sp(self.name_y))
 
-        GM_Endog_Error_Regimes.__init__(self, y=y, x=x, yend=yend,
+        GM_Endog_Error_Regimes.__init__(self, y=y, x=x_constant, yend=yend,
                                         q=q, regimes=regimes, w=w, vm=vm, constant_regi=constant_regi,
                                         cols2regi=cols2regi, regime_err_sep=regime_err_sep, cores=cores,
                                         name_y=self.name_y, name_x=name_x,
@@ -1272,8 +1280,7 @@ def _work_error(y, x, regi_ids, r, w, name_ds, name_y, name_x, name_w, name_regi
     w_r, warn = REGI.w_regime(w, regi_ids[r], r, transform=True)
     y_r = y[regi_ids[r]]
     x_r = x[regi_ids[r]]
-    x_constant = USER.check_constant(x_r)
-    model = BaseGM_Error(y_r, x_constant, w_r.sparse)
+    model = BaseGM_Error(y_r, x_r, w_r.sparse)
     set_warn(model, warn)
     model.w = w_r
     model.title = "SPATIALLY WEIGHTED LEAST SQUARES ESTIMATION - REGIME %s" % r
@@ -1296,9 +1303,8 @@ def _work_endog_error(y, x, yend, q, regi_ids, r, w, name_ds, name_y, name_x, na
         yend_r, q_r = None, None
     if add_lag != False:
         yend_r, q_r = set_endog(
-            y_r, x_r, w_r, yend_r, q_r, add_lag[0], add_lag[1])
-    x_constant = USER.check_constant(x_r)
-    model = BaseGM_Endog_Error(y_r, x_constant, yend_r, q_r, w_r.sparse)
+            y_r, x_r[:,1:], w_r, yend_r, q_r, add_lag[0], add_lag[1])
+    model = BaseGM_Endog_Error(y_r, x_r, yend_r, q_r, w_r.sparse)
     set_warn(model, warn)
     if add_lag != False:
         model.rho = model.betas[-2]

--- a/spreg/error_sp_regimes.py
+++ b/spreg/error_sp_regimes.py
@@ -281,7 +281,7 @@ class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                  cores=False, name_ds=None, name_regimes=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
@@ -705,7 +705,7 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                  name_ds=None, name_regimes=None, summ=True, add_lag=False):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
@@ -1223,7 +1223,7 @@ class GM_Combo_Regimes(GM_Endog_Error_Regimes, REGI.Regimes_Frame):
                  name_w=None, name_ds=None, name_regimes=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         name_x = USER.set_name_x(name_x, x, constant=True)
         self.name_y = USER.set_name_y(name_y)

--- a/spreg/error_sp_regimes.py
+++ b/spreg/error_sp_regimes.py
@@ -16,6 +16,7 @@ from .error_sp import BaseGM_Error, BaseGM_Endog_Error, _momentsGM_Error
 from .utils import set_endog, iter_msg, sp_att, set_warn
 from .utils import optim_moments, get_spFilter, get_lags
 from .utils import spdot, RegressionPropsY
+from .sputils import sphstack
 
 
 class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
@@ -309,6 +310,8 @@ class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             else:
                 raise Exception("All coefficients must vary accross regimes if regime_err_sep = True.")
         else:
+            x_constant = sphstack(np.ones((x_constant.shape[0], 1)), x_constant)
+            name_x = USER.set_name_x(name_x, x_constant)
             self.x, self.name_x = REGI.Regimes_Frame.__init__(self, x_constant,
                                                               regimes, constant_regi=None, cols2regi=cols2regi, names=name_x)
             ols = BaseOLS(y=y, x=self.x)
@@ -741,6 +744,8 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             else:
                 raise Exception("All coefficients must vary accross regimes if regime_err_sep = True.")
         else:
+            x_constant = sphstack(np.ones((x_constant.shape[0], 1)), x_constant)
+            name_x = USER.set_name_x(name_x, x_constant)
             q, name_q = REGI.Regimes_Frame.__init__(self, q,
                                                     regimes, constant_regi=None, cols2regi='all', names=name_q)
             x, name_x = REGI.Regimes_Frame.__init__(self, x_constant,
@@ -808,7 +813,7 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 is_win = False
         """
         x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
-        self.name_x_r = name_x
+        self.name_x_r = name_x  + name_yend
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
@@ -1257,7 +1262,7 @@ class GM_Combo_Regimes(GM_Endog_Error_Regimes, REGI.Regimes_Frame):
                 raise Exception("For spatial combo models, if spatial error is set by regimes (regime_err_sep=True), all coefficients including lambda (regime_lag_sep=True) must be set by regimes.")
             cols2regi += [False]
             add_lag = False
-            yend, q = set_endog(y, x_constant[:,1:], w, yend, q, w_lags, lag_q)
+            yend, q = set_endog(y, x_constant, w, yend, q, w_lags, lag_q)
         name_yend.append(USER.set_name_yend_sp(self.name_y))
 
         GM_Endog_Error_Regimes.__init__(self, y=y, x=x_constant, yend=yend,

--- a/spreg/ml_error.py
+++ b/spreg/ml_error.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.linalg as la
 from scipy import sparse as sp
 from scipy.sparse.linalg import splu as SuperLU
-from .utils import RegressionPropsY, RegressionPropsVM
+from .utils import RegressionPropsY, RegressionPropsVM, set_warn
 from . import diagnostics as DIAG
 from . import user_output as USER
 from . import summary_output as SUMMARY
@@ -452,7 +452,8 @@ class ML_Error(BaseML_Error):
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         method = method.upper()
         BaseML_Error.__init__(self, y=y, x=x_constant,
                               w=w, method=method, epsilon=epsilon)

--- a/spreg/ml_error.py
+++ b/spreg/ml_error.py
@@ -450,7 +450,7 @@ class ML_Error(BaseML_Error):
                  spat_diag=False, vm=False, name_y=None, name_x=None,
                  name_w=None, name_ds=None):
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant = USER.check_constant(x)
         method = method.upper()

--- a/spreg/ml_error_regimes.py
+++ b/spreg/ml_error_regimes.py
@@ -278,7 +278,7 @@ class ML_Error_Regimes(BaseML_Error, REGI.Regimes_Frame):
                  name_w=None, name_ds=None, name_regimes=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi

--- a/spreg/ml_error_regimes.py
+++ b/spreg/ml_error_regimes.py
@@ -12,6 +12,7 @@ from . import user_output as USER
 from . import summary_output as SUMMARY
 from . import diagnostics as DIAG
 from .utils import set_warn
+from .sputils import sphstack
 from .ml_error import BaseML_Error
 from platform import system
 
@@ -290,9 +291,10 @@ class ML_Error_Regimes(BaseML_Error, REGI.Regimes_Frame):
         self.n = n
         self.y = y
 
-        x_constant = USER.check_constant(x)
-        name_x = USER.set_name_x(name_x, x)
-        self.name_x_r = name_x
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
+        self.name_x_r = USER.set_name_x(name_x, x_constant)
 
         cols2regi = REGI.check_cols2regi(constant_regi, cols2regi, x)
         self.regimes_set = REGI._get_regimes_set(regimes)
@@ -302,11 +304,13 @@ class ML_Error_Regimes(BaseML_Error, REGI.Regimes_Frame):
 
         if regime_err_sep == True:
             if set(cols2regi) == set([True]):
-                self._error_regimes_multi(y, x, regimes, w, cores,
+                self._error_regimes_multi(y, x_constant, regimes, w, cores,
                                           method, epsilon, cols2regi, vm, name_x, spat_diag)
             else:
                 raise Exception("All coefficients must vary accross regimes if regime_err_sep = True.")
         else:
+            x_constant = sphstack(np.ones((x_constant.shape[0], 1)), x_constant)
+            name_x = USER.set_name_x(name_x, x_constant)
             regimes_att = {}
             regimes_att['x'] = x_constant
             regimes_att['regimes'] = regimes
@@ -345,14 +349,16 @@ class ML_Error_Regimes(BaseML_Error, REGI.Regimes_Frame):
                 results_p[r] = pool.apply_async(_work_error,args=(y,x,regi_ids,r,w,method,epsilon,self.name_ds,self.name_y,name_x+['lambda'],self.name_w,self.name_regimes, ))
                 is_win = False
         """
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        self.name_x_r = name_x
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work_error, args=(
-                    y, x, regi_ids, r, w, method, epsilon, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes, ))
+                    y, x_constant, regi_ids, r, w, method, epsilon, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes, ))
             else:
                 results_p[r] = _work_error(
-                    *(y, x, regi_ids, r, w, method, epsilon, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes))
+                    *(y, x_constant, regi_ids, r, w, method, epsilon, self.name_ds, self.name_y, name_x + ['lambda'], self.name_w, self.name_regimes))
 
         self.kryd = 0
         self.kr = len(cols2regi) + 1
@@ -407,9 +413,8 @@ def _work_error(y, x, regi_ids, r, w, method, epsilon, name_ds, name_y, name_x, 
     w_r, warn = REGI.w_regime(w, regi_ids[r], r, transform=True)
     y_r = y[regi_ids[r]]
     x_r = x[regi_ids[r]]
-    x_constant = USER.check_constant(x_r)
     model = BaseML_Error(
-        y=y_r, x=x_constant, w=w_r, method=method, epsilon=epsilon)
+        y=y_r, x=x_r, w=w_r, method=method, epsilon=epsilon)
     set_warn(model, warn)
     model.w = w_r
     model.title = "MAXIMUM LIKELIHOOD SPATIAL ERROR - REGIME " + \

--- a/spreg/ml_lag.py
+++ b/spreg/ml_lag.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.linalg as la
 from scipy import sparse as sp
 from scipy.sparse.linalg import splu as SuperLU
-from .utils import RegressionPropsY, RegressionPropsVM, inverse_prod
+from .utils import RegressionPropsY, RegressionPropsVM, inverse_prod, set_warn
 from .sputils import spdot, spfill_diagonal, spinv, spbroadcast
 from . import diagnostics as DIAG
 from . import user_output as USER
@@ -553,7 +553,8 @@ class ML_Lag(BaseML_Lag):
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         method = method.upper()
         BaseML_Lag.__init__(
             self, y=y, x=x_constant, w=w, method=method, epsilon=epsilon)

--- a/spreg/ml_lag.py
+++ b/spreg/ml_lag.py
@@ -551,7 +551,7 @@ class ML_Lag(BaseML_Lag):
                  spat_diag=False, vm=False, name_y=None, name_x=None,
                  name_w=None, name_ds=None):
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant = USER.check_constant(x)
         method = method.upper()

--- a/spreg/ml_lag_regimes.py
+++ b/spreg/ml_lag_regimes.py
@@ -301,15 +301,19 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         USER.check_spat_diag(spat_diag, w)
         name_y = USER.set_name_y(name_y)
         self.name_y = name_y
-        self.name_x_r = USER.set_name_x(
-            name_x, x) + [USER.set_name_yend_sp(name_y)]
+
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
+
+        self.name_x_r = name_x + [USER.set_name_yend_sp(name_y)]
         self.method = method
         self.epsilon = epsilon
         self.name_regimes = USER.set_name_ds(name_regimes)
         self.constant_regi = constant_regi
         self.n = n
         cols2regi = REGI.check_cols2regi(
-            constant_regi, cols2regi, x, add_cons=False)
+            constant_regi, cols2regi, x_constant, add_cons=False)
         self.cols2regi = cols2regi
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
@@ -317,7 +321,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         self._cache = {}
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_w = USER.set_name_w(name_w, w)
-        USER.check_regimes(self.regimes_set, self.n, x.shape[1])
+        USER.check_regimes(self.regimes_set, self.n, x_constant.shape[1])
 
         # regime_err_sep is ignored, always False
 
@@ -333,7 +337,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
 
         if set(cols2regi) == set([True]) and constant_regi == 'many':
             self.y = y
-            self.ML_Lag_Regimes_Multi(y, x, w_i, w, regi_ids,
+            self.ML_Lag_Regimes_Multi(y, x_constant, w_i, w, regi_ids,
                                       cores=cores, cols2regi=cols2regi, method=method, epsilon=epsilon,
                                       spat_diag=spat_diag, vm=vm, name_y=name_y, name_x=name_x,
                                       name_regimes=self.name_regimes,
@@ -341,8 +345,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         else:
             # if regime_lag_sep == True:
             #    w = REGI.w_regimes_union(w, w_i, self.regimes_set)
-            name_x = USER.set_name_x(name_x, x, constant=True)
-            x, self.name_x = REGI.Regimes_Frame.__init__(self, x,
+            x, self.name_x = REGI.Regimes_Frame.__init__(self, x_constant,
                                                          regimes, constant_regi, cols2regi=cols2regi[:-1], names=name_x)
             self.name_x.append("_Global_" + USER.set_name_yend_sp(name_y))
             BaseML_Lag.__init__(
@@ -364,7 +367,6 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                              spat_diag, vm, name_y, name_x,
                              name_regimes, name_w, name_ds):
         #        pool = mp.Pool(cores)
-        name_x = USER.set_name_x(name_x, x) + [USER.set_name_yend_sp(name_y)]
         results_p = {}
         """
         for r in self.regimes_set:
@@ -375,14 +377,16 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                 results_p[r] = pool.apply_async(_work,args=(y,x,regi_ids,r,w_i[r],method,epsilon,name_ds,name_y,name_x,name_w,name_regimes, ))
                 is_win = False
         """
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        name_x = name_x + [USER.set_name_yend_sp(name_y)]
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
-                results_p[r] = pool.apply_async(_work, args=(y, x, regi_ids, r, w_i[
+                results_p[r] = pool.apply_async(_work, args=(y, x_constant, regi_ids, r, w_i[
                                                 r], method, epsilon, name_ds, name_y, name_x, name_w, name_regimes, ))
             else:
                 results_p[r] = _work(
-                    *(y, x, regi_ids, r, w_i[r], method, epsilon, name_ds, name_y, name_x, name_w, name_regimes))
+                    *(y, x_constant, regi_ids, r, w_i[r], method, epsilon, name_ds, name_y, name_x, name_w, name_regimes))
 
         self.kryd = 0
         self.kr = len(cols2regi) + 1
@@ -439,8 +443,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
 def _work(y, x, regi_ids, r, w_r, method, epsilon, name_ds, name_y, name_x, name_w, name_regimes):
     y_r = y[regi_ids[r]]
     x_r = x[regi_ids[r]]
-    x_constant = USER.check_constant(x_r)
-    model = BaseML_Lag(y_r, x_constant, w_r, method=method, epsilon=epsilon)
+    model = BaseML_Lag(y_r, x_r, w_r, method=method, epsilon=epsilon)
     model.title = "MAXIMUM LIKELIHOOD SPATIAL LAG - REGIME " + \
         str(r) + " (METHOD = " + method + ")"
     model.name_ds = name_ds

--- a/spreg/ml_lag_regimes.py
+++ b/spreg/ml_lag_regimes.py
@@ -296,7 +296,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                  name_w=None, name_ds=None, name_regimes=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         USER.check_spat_diag(spat_diag, w)
         name_y = USER.set_name_y(name_y)

--- a/spreg/ols.py
+++ b/spreg/ols.py
@@ -427,7 +427,7 @@ class OLS(BaseOLS):
                  name_w=None, name_gwk=None, name_ds=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)

--- a/spreg/ols.py
+++ b/spreg/ols.py
@@ -7,7 +7,7 @@ import numpy.linalg as la
 from . import user_output as USER
 from . import summary_output as SUMMARY
 from . import robust as ROBUST
-from .utils import spdot, sphstack, RegressionPropsY, RegressionPropsVM
+from .utils import spdot, sphstack, RegressionPropsY, RegressionPropsVM, set_warn
 
 __all__ = ["OLS"]
 
@@ -431,13 +431,14 @@ class OLS(BaseOLS):
         USER.check_weights(w, y)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseOLS.__init__(self, y=y, x=x_constant, robust=robust,
                          gwk=gwk, sig2n_k=sig2n_k)
         self.title = "ORDINARY LEAST SQUARES"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.robust = USER.set_robust(robust)
         self.name_w = USER.set_name_w(name_w, w)
         self.name_gwk = USER.set_name_w(name_gwk, gwk)

--- a/spreg/ols_regimes.py
+++ b/spreg/ols_regimes.py
@@ -353,7 +353,7 @@ class OLS_Regimes(BaseOLS, REGI.Regimes_Frame, RegressionPropsY):
                  name_w=None, name_gwk=None, name_ds=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)

--- a/spreg/ols_regimes.py
+++ b/spreg/ols_regimes.py
@@ -14,6 +14,7 @@ import numpy as np
 import multiprocessing as mp
 from platform import system
 import scipy.sparse as SP
+import copy as COPY
 
 
 class OLS_Regimes(BaseOLS, REGI.Regimes_Frame, RegressionPropsY):
@@ -357,7 +358,10 @@ class OLS_Regimes(BaseOLS, REGI.Regimes_Frame, RegressionPropsY):
         USER.check_weights(w, y)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)
-        self.name_x_r = USER.set_name_x(name_x, x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
+        self.name_x_r = USER.set_name_x(name_x, x_constant)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
         self.name_w = USER.set_name_w(name_w, w)
@@ -367,10 +371,10 @@ class OLS_Regimes(BaseOLS, REGI.Regimes_Frame, RegressionPropsY):
         self.name_regimes = USER.set_name_ds(name_regimes)
         self.n = n
         cols2regi = REGI.check_cols2regi(
-            constant_regi, cols2regi, x, add_cons=False)
+            constant_regi, cols2regi, x_constant, add_cons=False)
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, self.n, x.shape[1])
+        USER.check_regimes(self.regimes_set, self.n, x_constant.shape[1])
         if regime_err_sep == True and robust == 'hac':
             set_warn(
                 self, "Error by regimes is incompatible with HAC estimation. Hence, error by regimes has been disabled for this model.")
@@ -378,14 +382,12 @@ class OLS_Regimes(BaseOLS, REGI.Regimes_Frame, RegressionPropsY):
         self.regime_err_sep = regime_err_sep
         if regime_err_sep == True and set(cols2regi) == set([True]) and constant_regi == 'many':
             self.y = y
-            name_x = USER.set_name_x(name_x, x)
             regi_ids = dict(
                 (r, list(np.where(np.array(regimes) == r)[0])) for r in self.regimes_set)
-            self._ols_regimes_multi(x, w, regi_ids, cores,
+            self._ols_regimes_multi(x_constant, w, regi_ids, cores,
                                     gwk, sig2n_k, robust, nonspat_diag, spat_diag, vm, name_x, moran, white_test)
         else:
-            name_x = USER.set_name_x(name_x, x, constant=True)
-            x, self.name_x = REGI.Regimes_Frame.__init__(self, x,
+            x, self.name_x = REGI.Regimes_Frame.__init__(self, x_constant,
                                                          regimes, constant_regi, cols2regi, name_x)
             BaseOLS.__init__(
                 self, y=y, x=x, robust=robust, gwk=gwk, sig2n_k=sig2n_k)
@@ -418,17 +420,18 @@ class OLS_Regimes(BaseOLS, REGI.Regimes_Frame, RegressionPropsY):
                 results_p[r] = pool.apply_async(_work,args=(self.y,x,w,regi_ids,r,robust,sig2n_k,self.name_ds,self.name_y,name_x,self.name_w,self.name_regimes))
                 is_win = False
         """
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        self.name_x_r = name_x
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work, args=(
-                    self.y, x, w, regi_ids, r, robust, sig2n_k, self.name_ds, self.name_y, name_x, self.name_w, self.name_regimes))
+                    self.y, x_constant, w, regi_ids, r, robust, sig2n_k, self.name_ds, self.name_y, name_x, self.name_w, self.name_regimes))
             else:
-                results_p[r] = _work(*(self.y, x, w, regi_ids, r, robust, sig2n_k,
+                results_p[r] = _work(*(self.y, x_constant, w, regi_ids, r, robust, sig2n_k,
                                        self.name_ds, self.name_y, name_x, self.name_w, self.name_regimes))
-
         self.kryd = 0
-        self.kr = x.shape[1] + 1
+        self.kr = x_constant.shape[1]
         self.kf = 0
         self.nr = len(self.regimes_set)
         self.vm = np.zeros((self.nr * self.kr, self.nr * self.kr), float)
@@ -469,19 +472,18 @@ class OLS_Regimes(BaseOLS, REGI.Regimes_Frame, RegressionPropsY):
             self.name_x += results[r].name_x
             counter += 1
         self.multi = results
-        self.hac_var = x
+        self.hac_var = x_constant[:,1:]
         if robust == 'hac':
             hac_multi(self, gwk)
         self.chow = REGI.Chow(self)
         if spat_diag:
-            self._get_spat_diag_props(x, sig2n_k)
+            self._get_spat_diag_props(x_constant, sig2n_k)
         SUMMARY.OLS_multi(reg=self, multireg=self.multi, vm=vm, nonspat_diag=nonspat_diag,
                           spat_diag=spat_diag, moran=moran, white_test=white_test, regimes=True, w=w)
 
     def _get_spat_diag_props(self, x, sig2n_k):
         self.k = self.kr
         self._cache = {}
-        x = np.hstack((np.ones((x.shape[0], 1)), x))
         self.x = REGI.regimeX_setup(
             x, self.regimes, [True] * x.shape[1], self.regimes_set)
         self.xtx = spdot(self.x.T, self.x)
@@ -491,10 +493,11 @@ class OLS_Regimes(BaseOLS, REGI.Regimes_Frame, RegressionPropsY):
 def _work(y, x, w, regi_ids, r, robust, sig2n_k, name_ds, name_y, name_x, name_w, name_regimes):
     y_r = y[regi_ids[r]]
     x_r = x[regi_ids[r]]
-    x_constant = USER.check_constant(x_r)
+    #x_constant,name_x,warn = USER.check_constant(x_r, name_x)
+    #name_x = USER.set_name_x(name_x, x_constant)
     if robust == 'hac':
         robust = None
-    model = BaseOLS(y_r, x_constant, robust=robust, sig2n_k=sig2n_k)
+    model = BaseOLS(y_r, x_r, robust=robust, sig2n_k=sig2n_k)
     model.title = "ORDINARY LEAST SQUARES ESTIMATION - REGIME %s" % r
     model.robust = USER.set_robust(robust)
     model.name_ds = name_ds

--- a/spreg/probit.py
+++ b/spreg/probit.py
@@ -10,7 +10,7 @@ chisqprob = chi2.sf
 import scipy.sparse as SP
 from . import user_output as USER
 from . import summary_output as SUMMARY
-from .utils import spdot, spbroadcast
+from .utils import spdot, spbroadcast, set_warn
 
 __all__ = ["Probit"]
 
@@ -809,7 +809,9 @@ class Probit(BaseProbit):
             ws = w.sparse
         else:
             ws = None
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
+
         BaseProbit.__init__(self, y=y, x=x_constant, w=ws,
                             optim=optim, scalem=scalem, maxiter=maxiter)
         self.title = "CLASSIC PROBIT ESTIMATOR"

--- a/spreg/probit.py
+++ b/spreg/probit.py
@@ -802,7 +802,7 @@ class Probit(BaseProbit):
             spat_diag=False):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         if w != None:
             USER.check_weights(w, y)
             spat_diag = True

--- a/spreg/summary_output.py
+++ b/spreg/summary_output.py
@@ -83,7 +83,7 @@ def OLS_multi(reg, multireg, vm, nonspat_diag, spat_diag, moran, white_test, reg
             summary_regimes(mreg, chow=False)
         if sur:
             summary_sur(mreg)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     if regimes:
@@ -93,7 +93,7 @@ def OLS_multi(reg, multireg, vm, nonspat_diag, spat_diag, moran, white_test, reg
     if spat_diag:
         # compute global diagnostics and organize summary output
         spat_diag_ols(reg, w, moran)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm, instruments=False,
                   nonspat_diag=nonspat_diag, spat_diag=spat_diag)
 
@@ -129,7 +129,7 @@ def TSLS_multi(reg, multireg, vm, spat_diag, regimes=False, sur=False, w=False):
             summary_regimes(mreg, chow=False)
         if sur:
             summary_sur(mreg)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     if regimes:
@@ -139,7 +139,7 @@ def TSLS_multi(reg, multireg, vm, spat_diag, regimes=False, sur=False, w=False):
     if spat_diag:
         # compute global diagnostics and organize summary output
         spat_diag_instruments(reg, w)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=True, nonspat_diag=False, spat_diag=spat_diag)
 
@@ -177,7 +177,7 @@ def GM_Lag_multi(reg, multireg, vm, spat_diag, regimes=False, sur=False, w=False
             summary_regimes(mreg, chow=False)
         if sur:
             summary_sur(mreg)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     if regimes:
@@ -186,7 +186,7 @@ def GM_Lag_multi(reg, multireg, vm, spat_diag, regimes=False, sur=False, w=False
         pass
         # compute global diagnostics and organize summary output
         #spat_diag_instruments(reg, w)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=True, nonspat_diag=False, spat_diag=spat_diag)
 
@@ -227,12 +227,12 @@ def ML_Lag_multi(reg, multireg, vm, spat_diag, regimes=False, sur=False, w=False
         summary_coefs_allx(mreg, mreg.z_stat)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     if regimes:
         summary_chow(reg)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=False, nonspat_diag=False, spat_diag=False)
 
@@ -273,12 +273,12 @@ def ML_Error_multi(reg, multireg, vm, spat_diag, regimes=False, sur=False, w=Fal
         summary_coefs_allx(mreg, mreg.z_stat)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     if regimes:
         summary_chow(reg, lambd=True)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=False, nonspat_diag=False, spat_diag=False)
 
@@ -308,11 +308,11 @@ def GM_Error_multi(reg, multireg, vm, regimes=False):
         summary_coefs_lambda(mreg, mreg.z_stat)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     summary_chow(reg, lambd=False)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=False, nonspat_diag=False, spat_diag=False)
 
@@ -344,11 +344,11 @@ def GM_Endog_Error_multi(reg, multireg, vm, regimes=False):
         summary_coefs_instruments(mreg)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     summary_chow(reg, lambd=False)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=True, nonspat_diag=False, spat_diag=False)
 
@@ -380,11 +380,11 @@ def GM_Error_Hom_multi(reg, multireg, vm, regimes=False):
         summary_coefs_lambda(mreg, mreg.z_stat)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     summary_chow(reg, lambd=True)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=False, nonspat_diag=False, spat_diag=False)
 
@@ -418,11 +418,11 @@ def GM_Endog_Error_Hom_multi(reg, multireg, vm, regimes=False):
         summary_coefs_instruments(mreg)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     summary_chow(reg, lambd=True)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=True, nonspat_diag=False, spat_diag=False)
 
@@ -454,11 +454,11 @@ def GM_Error_Het_multi(reg, multireg, vm, regimes=False):
         summary_coefs_lambda(mreg, mreg.z_stat)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     summary_chow(reg, lambd=True)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=False, nonspat_diag=False, spat_diag=False)
 
@@ -492,11 +492,11 @@ def GM_Endog_Error_Het_multi(reg, multireg, vm, regimes=False):
         summary_coefs_instruments(mreg)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     summary_chow(reg, lambd=True)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=True, nonspat_diag=False, spat_diag=False)
 
@@ -529,12 +529,12 @@ def GM_Combo_multi(reg, multireg, vm, regimes=False):
         summary_coefs_instruments(mreg)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     if regimes:
         summary_chow(reg, lambd=False)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=True, nonspat_diag=False, spat_diag=False)
 
@@ -568,12 +568,12 @@ def GM_Combo_Hom_multi(reg, multireg, vm, regimes=False):
         summary_coefs_instruments(mreg)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     if regimes:
         summary_chow(reg, lambd=True)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=True, nonspat_diag=False, spat_diag=False)
 
@@ -607,12 +607,12 @@ def GM_Combo_Het_multi(reg, multireg, vm, regimes=False):
         summary_coefs_instruments(mreg)
         if regimes:
             summary_regimes(mreg, chow=False)
-        summary_warning(mreg)
+        summary_warning(mreg,reg)
         multireg[m].__summary = mreg.__summary
     reg.__summary = {}
     if regimes:
         summary_chow(reg, lambd=True)
-    summary_warning(reg)
+    #summary_warning(reg)
     summary_multi(reg=reg, multireg=multireg, vm=vm,
                   instruments=True, nonspat_diag=False, spat_diag=False)
 
@@ -1237,13 +1237,20 @@ def summary_chow(reg, lambd=False, sur=False):
         reg.__summary[eq]['summary_chow'] = sum_text
 
 
-def summary_warning(reg):
+def summary_warning(reg, global_reg=None):
     try:
         if reg.warning:
             try:
                 reg.__summary['summary_other_mid'] += reg.warning
             except:
                 reg.__summary['summary_other_mid'] = reg.warning
+    except:
+        pass
+    try:
+        try:
+            reg.__summary['summary_other_mid'] += global_reg.warning
+        except:
+            reg.__summary['summary_other_mid'] = global_reg.warning
     except:
         pass
 

--- a/spreg/tests/test_ml_error.py
+++ b/spreg/tests/test_ml_error.py
@@ -4,7 +4,7 @@ from libpysal.examples import load_example
 from libpysal.weights import Queen
 import numpy as np
 from scipy import sparse
-from ..ml_error import ML_Error
+from spreg.ml_error import ML_Error
 from libpysal.common import RTOL, ATOL
 from warnings import filterwarnings
 filterwarnings('ignore', category=sparse.SparseEfficiencyWarning)

--- a/spreg/tests/test_ml_error_regimes.py
+++ b/spreg/tests/test_ml_error_regimes.py
@@ -2,8 +2,8 @@ import unittest
 import libpysal
 import numpy as np
 from scipy import sparse
-from ..ml_error_regimes import ML_Error_Regimes
-from ..ml_error import ML_Error
+from spreg.ml_error_regimes import ML_Error_Regimes
+from spreg.ml_error import ML_Error
 from libpysal.common import RTOL
 from warnings import filterwarnings
 

--- a/spreg/tests/test_ml_lag.py
+++ b/spreg/tests/test_ml_lag.py
@@ -2,7 +2,7 @@ import unittest
 import libpysal
 from scipy import sparse
 import numpy as np
-from ..ml_lag import ML_Lag
+from spreg.ml_lag import ML_Lag
 from libpysal.common import RTOL
 from warnings import filterwarnings
 filterwarnings('ignore', category=sparse.SparseEfficiencyWarning)

--- a/spreg/tests/test_ml_lag_regimes.py
+++ b/spreg/tests/test_ml_lag_regimes.py
@@ -2,7 +2,7 @@ import unittest
 import libpysal
 from scipy import sparse
 import numpy as np
-from ..ml_lag_regimes import ML_Lag_Regimes
+from spreg.ml_lag_regimes import ML_Lag_Regimes
 from libpysal.common import RTOL
 
 from warnings import filterwarnings

--- a/spreg/twosls.py
+++ b/spreg/twosls.py
@@ -442,13 +442,13 @@ class TSLS(BaseTSLS):
         USER.check_weights(w, y)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)
-        x_constant = USER.check_constant(x)
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
         BaseTSLS.__init__(self, y=y, x=x_constant, yend=yend, q=q,
                           robust=robust, gwk=gwk, sig2n_k=sig2n_k)
         self.title = "TWO STAGE LEAST SQUARES"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_z = self.name_x + self.name_yend
         self.name_q = USER.set_name_q(name_q, q)

--- a/spreg/twosls.py
+++ b/spreg/twosls.py
@@ -438,7 +438,7 @@ class TSLS(BaseTSLS):
                  name_w=None, name_gwk=None, name_ds=None):
 
         n = USER.check_arrays(y, x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)

--- a/spreg/twosls.py
+++ b/spreg/twosls.py
@@ -3,7 +3,7 @@ import numpy.linalg as la
 from . import summary_output as SUMMARY
 from . import robust as ROBUST
 from . import user_output as USER
-from .utils import spdot, sphstack, RegressionPropsY, RegressionPropsVM
+from .utils import spdot, sphstack, RegressionPropsY, RegressionPropsVM, set_warn
 
 __author__ = "Luc Anselin luc.anselin@asu.edu, David C. Folch david.folch@asu.edu, Jing Yao jingyao@asu.edu"
 __all__ = ["TSLS"]
@@ -443,6 +443,7 @@ class TSLS(BaseTSLS):
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)
         x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseTSLS.__init__(self, y=y, x=x_constant, yend=yend, q=q,
                           robust=robust, gwk=gwk, sig2n_k=sig2n_k)
         self.title = "TWO STAGE LEAST SQUARES"

--- a/spreg/twosls_regimes.py
+++ b/spreg/twosls_regimes.py
@@ -279,7 +279,7 @@ class TSLS_Regimes(BaseTSLS, REGI.Regimes_Frame):
                  name_w=None, name_gwk=None, name_ds=None, summ=True):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)

--- a/spreg/twosls_regimes.py
+++ b/spreg/twosls_regimes.py
@@ -283,6 +283,9 @@ class TSLS_Regimes(BaseTSLS, REGI.Regimes_Frame):
         USER.check_weights(w, y)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
         self.constant_regi = constant_regi
         self.cols2regi = cols2regi
         self.name_ds = USER.set_name_ds(name_ds)
@@ -292,30 +295,28 @@ class TSLS_Regimes(BaseTSLS, REGI.Regimes_Frame):
         self.name_y = USER.set_name_y(name_y)
         name_yend = USER.set_name_yend(name_yend, yend)
         name_q = USER.set_name_q(name_q, q)
-        self.name_x_r = USER.set_name_x(name_x, x) + name_yend
+        self.name_x_r = USER.set_name_x(name_x, x_constant) + name_yend
         self.n = n
         cols2regi = REGI.check_cols2regi(
-            constant_regi, cols2regi, x, yend=yend, add_cons=False)
+            constant_regi, cols2regi, x_constant, yend=yend, add_cons=False)
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, self.n, x.shape[1])
+        USER.check_regimes(self.regimes_set, self.n, x_constant.shape[1])
         if regime_err_sep == True and robust == 'hac':
             set_warn(
                 self, "Error by regimes is incompatible with HAC estimation for 2SLS models. Hence, the error by regimes has been disabled for this model.")
             regime_err_sep = False
         self.regime_err_sep = regime_err_sep
         if regime_err_sep == True and set(cols2regi) == set([True]) and constant_regi == 'many':
-            name_x = USER.set_name_x(name_x, x)
             self.y = y
             regi_ids = dict(
                 (r, list(np.where(np.array(regimes) == r)[0])) for r in self.regimes_set)
-            self._tsls_regimes_multi(x, yend, q, w, regi_ids, cores,
+            self._tsls_regimes_multi(x_constant, yend, q, w, regi_ids, cores,
                                      gwk, sig2n_k, robust, spat_diag, vm, name_x, name_yend, name_q)
         else:
-            name_x = USER.set_name_x(name_x, x, constant=True)
             q, self.name_q = REGI.Regimes_Frame.__init__(self, q,
                                                          regimes, constant_regi=None, cols2regi='all', names=name_q)
-            x, self.name_x = REGI.Regimes_Frame.__init__(self, x,
+            x, self.name_x = REGI.Regimes_Frame.__init__(self, x_constant,
                                                          regimes, constant_regi, cols2regi=cols2regi, names=name_x)
             yend, self.name_yend = REGI.Regimes_Frame.__init__(self, yend,
                                                                regimes, constant_regi=None,
@@ -348,17 +349,19 @@ class TSLS_Regimes(BaseTSLS, REGI.Regimes_Frame):
                 results_p[r] = pool.apply_async(_work,args=(self.y,x,w,regi_ids,r,yend,q,robust,sig2n_k,self.name_ds,self.name_y,name_x,name_yend,name_q,self.name_w,self.name_regimes))
                 is_win = False
         """
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        self.name_x_r = name_x
         for r in self.regimes_set:
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work, args=(
-                    self.y, x, w, regi_ids, r, yend, q, robust, sig2n_k, self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes))
+                    self.y, x_constant, w, regi_ids, r, yend, q, robust, sig2n_k, self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes))
             else:
-                results_p[r] = _work(*(self.y, x, w, regi_ids, r, yend, q, robust, sig2n_k,
+                results_p[r] = _work(*(self.y, x_constant, w, regi_ids, r, yend, q, robust, sig2n_k,
                                        self.name_ds, self.name_y, name_x, name_yend, name_q, self.name_w, self.name_regimes))
 
         self.kryd = 0
-        self.kr = x.shape[1] + yend.shape[1] + 1
+        self.kr = x_constant.shape[1] + yend.shape[1]
         self.kf = 0
         self.nr = len(self.regimes_set)
         self.vm = np.zeros((self.nr * self.kr, self.nr * self.kr), float)
@@ -404,7 +407,7 @@ class TSLS_Regimes(BaseTSLS, REGI.Regimes_Frame):
             self.name_h += results[r].name_h
             counter += 1
         self.multi = results
-        self.hac_var = sphstack(x, q)
+        self.hac_var = sphstack(x_constant[:,1:], q)
         if robust == 'hac':
             hac_multi(self, gwk)
         if robust == 'ogmm':
@@ -412,13 +415,12 @@ class TSLS_Regimes(BaseTSLS, REGI.Regimes_Frame):
                 self, "Residuals treated as homoskedastic for the purpose of diagnostics.")
         self.chow = REGI.Chow(self)
         if spat_diag:
-            self._get_spat_diag_props(results, regi_ids, x, yend, q)
+            self._get_spat_diag_props(results, regi_ids, x_constant, yend, q)
         SUMMARY.TSLS_multi(
             reg=self, multireg=self.multi, vm=vm, spat_diag=spat_diag, regimes=True, w=w)
 
     def _get_spat_diag_props(self, results, regi_ids, x, yend, q):
         self._cache = {}
-        x = USER.check_constant(x)
         x = REGI.regimeX_setup(
             x, self.regimes, [True] * x.shape[1], self.regimes_set)
         self.z = sphstack(x, REGI.regimeX_setup(
@@ -435,13 +437,12 @@ def _work(y, x, w, regi_ids, r, yend, q, robust, sig2n_k, name_ds, name_y, name_
     x_r = x[regi_ids[r]]
     yend_r = yend[regi_ids[r]]
     q_r = q[regi_ids[r]]
-    x_constant = USER.check_constant(x_r)
     if robust == 'hac' or robust == 'ogmm':
         robust2 = None
     else:
         robust2 = robust
     model = BaseTSLS(
-        y_r, x_constant, yend_r, q_r, robust=robust2, sig2n_k=sig2n_k)
+        y_r, x_r, yend_r, q_r, robust=robust2, sig2n_k=sig2n_k)
     model.title = "TWO STAGE LEAST SQUARES ESTIMATION - REGIME %s" % r
     if robust == 'ogmm':
         _optimal_weight(model, sig2n_k, warn=False)

--- a/spreg/twosls_sp.py
+++ b/spreg/twosls_sp.py
@@ -468,7 +468,7 @@ class GM_Lag(BaseGM_Lag):
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         USER.check_robust(robust, gwk)
-        x_constant = USER.check_constant(x)        
+        x_constant,name_x,warn = USER.check_constant(x,name_x)
         BaseGM_Lag.__init__(
             self, y=y, x=x_constant, w=w, yend=yend, q=q,
             w_lags=w_lags, robust=robust, gwk=gwk,
@@ -480,7 +480,7 @@ class GM_Lag(BaseGM_Lag):
         self.title = "SPATIAL TWO STAGE LEAST SQUARES"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_yend.append(USER.set_name_yend_sp(self.name_y))
         self.name_z = self.name_x + self.name_yend

--- a/spreg/twosls_sp.py
+++ b/spreg/twosls_sp.py
@@ -469,6 +469,7 @@ class GM_Lag(BaseGM_Lag):
         USER.check_weights(w, y, w_required=True)
         USER.check_robust(robust, gwk)
         x_constant,name_x,warn = USER.check_constant(x,name_x)
+        set_warn(self, warn)
         BaseGM_Lag.__init__(
             self, y=y, x=x_constant, w=w, yend=yend, q=q,
             w_lags=w_lags, robust=robust, gwk=gwk,

--- a/spreg/twosls_sp.py
+++ b/spreg/twosls_sp.py
@@ -465,7 +465,7 @@ class GM_Lag(BaseGM_Lag):
                  name_w=None, name_gwk=None, name_ds=None):
 
         n = USER.check_arrays(x, yend, q)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         USER.check_robust(robust, gwk)
         x_constant = USER.check_constant(x)        

--- a/spreg/twosls_sp_regimes.py
+++ b/spreg/twosls_sp_regimes.py
@@ -437,7 +437,9 @@ class GM_Lag_Regimes(TSLS_Regimes, REGI.Regimes_Frame):
         USER.check_weights(w, y, w_required=True)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)
-        name_x = USER.set_name_x(name_x, x, constant=True)
+        x_constant,name_x,warn = USER.check_constant(x,name_x,just_rem=True)
+        set_warn(self,warn)
+        name_x = USER.set_name_x(name_x, x_constant, constant=True)
         name_y = USER.set_name_y(name_y)
         name_yend = USER.set_name_yend(name_yend, yend)
         name_q = USER.set_name_q(name_q, q)
@@ -447,11 +449,11 @@ class GM_Lag_Regimes(TSLS_Regimes, REGI.Regimes_Frame):
         self.constant_regi = constant_regi
         self.n = n
         cols2regi = REGI.check_cols2regi(
-            constant_regi, cols2regi, x, yend=yend, add_cons=False)
+            constant_regi, cols2regi, x_constant, yend=yend, add_cons=False)
         self.cols2regi = cols2regi
         self.regimes_set = REGI._get_regimes_set(regimes)
         self.regimes = regimes
-        USER.check_regimes(self.regimes_set, self.n, x.shape[1])
+        USER.check_regimes(self.regimes_set, self.n, x_constant.shape[1])
         if regime_err_sep == True and robust == 'hac':
             set_warn(
                 self, "Error by regimes is incompatible with HAC estimation for Spatial Lag models. Hence, error and lag by regimes have been disabled for this model.")
@@ -472,7 +474,7 @@ class GM_Lag_Regimes(TSLS_Regimes, REGI.Regimes_Frame):
 
         if regime_err_sep == True and set(cols2regi) == set([True]) and constant_regi == 'many':
             self.y = y
-            self.GM_Lag_Regimes_Multi(y, x, w_i, w, regi_ids,
+            self.GM_Lag_Regimes_Multi(y, x_constant, w_i, w, regi_ids,
                                       yend=yend, q=q, w_lags=w_lags, lag_q=lag_q, cores=cores,
                                       robust=robust, gwk=gwk, sig2n_k=sig2n_k, cols2regi=cols2regi,
                                       spat_diag=spat_diag, vm=vm, name_y=name_y, name_x=name_x,
@@ -481,9 +483,9 @@ class GM_Lag_Regimes(TSLS_Regimes, REGI.Regimes_Frame):
         else:
             if regime_lag_sep == True:
                 w = REGI.w_regimes_union(w, w_i, self.regimes_set)
-            yend2, q2 = set_endog(y, x, w, yend, q, w_lags, lag_q)
+            yend2, q2 = set_endog(y, x_constant, w, yend, q, w_lags, lag_q)
             name_yend.append(USER.set_name_yend_sp(name_y))
-            TSLS_Regimes.__init__(self, y=y, x=x, yend=yend2, q=q2,
+            TSLS_Regimes.__init__(self, y=y, x=x_constant, yend=yend2, q=q2,
                                   regimes=regimes, w=w, robust=robust, gwk=gwk,
                                   sig2n_k=sig2n_k, spat_diag=spat_diag, vm=vm,
                                   constant_regi=constant_regi, cols2regi=cols2regi, regime_err_sep=regime_err_sep,
@@ -510,7 +512,6 @@ class GM_Lag_Regimes(TSLS_Regimes, REGI.Regimes_Frame):
                              name_w=None, name_gwk=None, name_ds=None):
         #        pool = mp.Pool(cores)
         self.name_ds = USER.set_name_ds(name_ds)
-        name_x = USER.set_name_x(name_x, x)
         name_yend.append(USER.set_name_yend_sp(name_y))
         self.name_w = USER.set_name_w(name_w, w_i)
         self.name_gwk = USER.set_name_w(name_gwk, gwk)
@@ -525,18 +526,20 @@ class GM_Lag_Regimes(TSLS_Regimes, REGI.Regimes_Frame):
                 results_p[r] = pool.apply_async(_work,args=(y,x,regi_ids,r,yend,q,w_r,w_lags,lag_q,robust,sig2n_k,self.name_ds,name_y,name_x,name_yend,name_q,self.name_w,name_regimes, ))
                 is_win = False
         """
+        x_constant,name_x = REGI.check_const_regi(self,x,name_x,regi_ids)
+        self.name_x_r = name_x
         for r in self.regimes_set:
             w_r = w_i[r].sparse
             if cores:
                 pool = mp.Pool(None)
                 results_p[r] = pool.apply_async(_work, args=(
-                    y, x, regi_ids, r, yend, q, w_r, w_lags, lag_q, robust, sig2n_k, self.name_ds, name_y, name_x, name_yend, name_q, self.name_w, name_regimes, ))
+                    y, x_constant, regi_ids, r, yend, q, w_r, w_lags, lag_q, robust, sig2n_k, self.name_ds, name_y, name_x, name_yend, name_q, self.name_w, name_regimes, ))
             else:
-                results_p[r] = _work(*(y, x, regi_ids, r, yend, q, w_r, w_lags, lag_q, robust,
+                results_p[r] = _work(*(y, x_constant, regi_ids, r, yend, q, w_r, w_lags, lag_q, robust,
                                        sig2n_k, self.name_ds, name_y, name_x, name_yend, name_q, self.name_w, name_regimes))
 
         self.kryd = 0
-        self.kr = len(cols2regi) + 1
+        self.kr = len(cols2regi)+1
         self.kf = 0
         self.nr = len(self.regimes_set)
         self.name_x_r = name_x + name_yend
@@ -621,8 +624,8 @@ class GM_Lag_Regimes(TSLS_Regimes, REGI.Regimes_Frame):
 
     def _get_spat_diag_props(self, y, x, w, yend, q, w_lags, lag_q):
         self._cache = {}
-        yend, q = set_endog(y, x, w, yend, q, w_lags, lag_q)
-        x = USER.check_constant(x)
+        yend, q = set_endog(y, x[:,1:], w, yend, q, w_lags, lag_q)
+        #x = USER.check_constant(x)
         x = REGI.regimeX_setup(
             x, self.regimes, [True] * x.shape[1], self.regimes_set)
         self.z = sphstack(x, REGI.regimeX_setup(
@@ -645,14 +648,14 @@ def _work(y, x, regi_ids, r, yend, q, w_r, w_lags, lag_q, robust, sig2n_k, name_
         q_r = q[regi_ids[r]]
     else:
         q_r = q
-    yend_r, q_r = set_endog_sparse(y_r, x_r, w_r, yend_r, q_r, w_lags, lag_q)
-    x_constant = USER.check_constant(x_r)
+    yend_r, q_r = set_endog_sparse(y_r, x_r[:,1:], w_r, yend_r, q_r, w_lags, lag_q)
+    #x_constant = USER.check_constant(x_r)
     if robust == 'hac' or robust == 'ogmm':
         robust2 = None
     else:
         robust2 = robust
     model = BaseTSLS(
-        y_r, x_constant, yend_r, q_r, robust=robust2, sig2n_k=sig2n_k)
+        y_r, x_r, yend_r, q_r, robust=robust2, sig2n_k=sig2n_k)
     model.title = "SPATIAL TWO STAGE LEAST SQUARES ESTIMATION - REGIME %s" % r
     if robust == 'ogmm':
         _optimal_weight(model, sig2n_k, warn=False)

--- a/spreg/twosls_sp_regimes.py
+++ b/spreg/twosls_sp_regimes.py
@@ -433,7 +433,7 @@ class GM_Lag_Regimes(TSLS_Regimes, REGI.Regimes_Frame):
                  name_w=None, name_gwk=None, name_ds=None):
 
         n = USER.check_arrays(y, x)
-        USER.check_y(y, n)
+        y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         USER.check_robust(robust, gwk)
         USER.check_spat_diag(spat_diag, w)

--- a/spreg/user_output.py
+++ b/spreg/user_output.py
@@ -613,12 +613,18 @@ def check_constant(x,name_x=None,just_rem=False):
 
     """
     x_constant = COPY.copy(x)
-    diffs = np.ptp(x_constant,axis=0)
     keep_x = COPY.copy(name_x)
     warn = None
+    if isinstance(x_constant, np.ndarray):
+        diffs = np.ptp(x_constant,axis=0)
+        if sum(diffs==0) > 0:
+            x_constant = np.delete(x_constant,np.nonzero(diffs==0),1)
+    else:
+        diffs = (x_constant.max(axis=0).toarray()-x_constant.min(axis=0).toarray())[0]
+        if sum(diffs==0) > 0:
+            x_constant = x_constant[:,np.nonzero(diffs>0)[0]]
 
     if sum(diffs==0) > 0:
-        x_constant = np.delete(x_constant,np.nonzero(diffs==0),1)
         if keep_x:
             rem_x = [keep_x[i] for i in np.nonzero(diffs==0)[0]]
             warn = 'Variable(s) '+str(rem_x)+' removed for being constant.'

--- a/spreg/user_output.py
+++ b/spreg/user_output.py
@@ -327,9 +327,9 @@ def check_arrays(*arrays):
             raise Exception("all input data must be either numpy arrays or sparse csr matrices")
         shape = i.shape
         if len(shape) > 2:
-            raise Exception("all input arrays must have exactly two dimensions")
+            raise Exception("all input arrays must have two dimensions")
         if len(shape) == 1:
-            raise Exception("all input arrays must have exactly two dimensions")
+            shape = (shape[0],1)
         if shape[0] < shape[1]:
             raise Exception("one or more input arrays have more columns than rows")
         if not spu.spisfinite(i):
@@ -357,8 +357,8 @@ def check_y(y, n):
 
     Returns
     -------
-    Returns : nothing
-              Nothing is returned
+    y       : anything
+              Object passed by the user to a regression class
 
     Examples
     --------
@@ -372,7 +372,7 @@ def check_y(y, n):
 
     >>> y = np.array(db.by_col("CRIME"))
     >>> y = np.reshape(y, (49,1))
-    >>> check_y(y, 49)
+    >>> y = check_y(y, 49)
 
     # should not raise an exception
 
@@ -390,7 +390,7 @@ def check_y(y, n):
             raise Exception("y must be a single column array matching the length of other arrays")
     if shape != (n, 1):
         raise Exception("y must be a single column array matching the length of other arrays")
-
+    return y
 
 def check_weights(w, y, w_required=False):
     """Check if the w parameter passed by the user is a libpysal.W object and

--- a/spreg/user_output.py
+++ b/spreg/user_output.py
@@ -62,7 +62,7 @@ def set_name_x(name_x, x, constant=False):
                   User provided exogenous variable names.
 
     x           : array
-                  User provided exogenous variables.
+                  User provided exogenous variables including the constant.
     constant    : boolean
                   If False (default), constant name not included in name_x list yet
                   Append 'CONSTANT' at the front of the names
@@ -73,7 +73,7 @@ def set_name_x(name_x, x, constant=False):
 
     """
     if not name_x:
-        name_x = ['var_' + str(i + 1) for i in range(x.shape[1])]
+        name_x = ['var_' + str(i + 1) for i in range(x.shape[1]-1+int(constant))]
     else:
         name_x = name_x[:]
     if not constant:
@@ -392,7 +392,7 @@ def check_y(y, n):
         raise Exception("y must be a single column array matching the length of other arrays")
     return y
 
-def check_weights(w, y, w_required=False):
+def check_weights(w, y, w_required=False, time=False):
     """Check if the w parameter passed by the user is a libpysal.W object and
     check that its dimensionality matches the y parameter.  Note that this
     check is not performed if w set to None.
@@ -405,6 +405,11 @@ def check_weights(w, y, w_required=False):
     y       : numpy array
               Any shape numpy array can be passed. Note: if y passed
               check_arrays, then it will be valid for this function
+    w_required : boolean
+                 True if a W matrix is required, False (default) if not.
+    time    : boolean
+              True if data contains a time dimension.
+              False (default) if not.
 
     Returns
     -------
@@ -436,7 +441,7 @@ def check_weights(w, y, w_required=False):
         if not isinstance(w, weights.W):
             from warnings import warn
             warn("w must be API-compatible pysal weights object")
-        if w.n != y.shape[0]:
+        if w.n != y.shape[0] and time == False:
             raise Exception("y must be nx1, and w must be an nxn PySAL W object")
         diag = w.sparse.diagonal()
         # check to make sure all entries equal 0
@@ -574,20 +579,24 @@ def check_regimes(reg_set, N=None, K=None):
         raise Exception("There aren't enough observations for the given number of regimes and variables. Please check your regimes variable.")
 
 
-def check_constant(x):
-    """Check if the X matrix contains a constant, raise exception if it does
-    not
+def check_constant(x,name_x=None,just_rem=False):
+    """Check if the X matrix contains a constant. If it does, drop the constant and replace by a vector of ones.
 
     Parameters
     ----------
     x           : array
                   Value passed by a used to a regression class
-
+    name_x      : list of strings
+                  Names of independent variables
+    just_rem    : boolean
+                  If False (default), remove all constants and add a vector of ones
+                  If True, just remove all constants
     Returns
     -------
-    Returns : nothing
-              Nothing is returned
-
+    x_constant : array
+                 Matrix with independent variables plus constant
+    name_x     : list of strings
+                 Names of independent variables (updated if any variable droped)
     Examples
     --------
     >>> import numpy as np
@@ -598,17 +607,31 @@ def check_constant(x):
     >>> X.append(db.by_col("INC"))
     >>> X.append(db.by_col("HOVAL"))
     >>> X = np.array(X).T
-    >>> x_constant = check_constant(X)
+    >>> x_constant,_ = check_constant(X)
     >>> x_constant.shape
     (49, 3)
 
     """
-    if diagnostics.constant_check(x):
-        raise Exception("x array cannot contain a constant vector; constant will be added automatically")
-    else:
-        x_constant = COPY.copy(x)
-        return spu.sphstack(np.ones((x_constant.shape[0], 1)), x_constant)
+    x_constant = COPY.copy(x)
+    diffs = np.ptp(x_constant,axis=0)
+    keep_x = COPY.copy(name_x)
+    warn = None
 
+    if sum(diffs==0) > 0:
+        x_constant = np.delete(x_constant,np.nonzero(diffs==0),1)
+        if keep_x:
+            rem_x = [keep_x[i] for i in np.nonzero(diffs==0)[0]]
+            warn = 'Variable(s) '+str(rem_x)+' removed for being constant.'
+            keep_x[:] = [keep_x[i] for i in np.nonzero(diffs>0)[0]]
+        else:
+            if sum(diffs==0) == 1:
+                warn = 'One variable has been removed for being constant.'           
+            else:
+                warn = str(sum(diffs==0))+' variables have been removed for being constant.'        
+    if not just_rem:
+        return spu.sphstack(np.ones((x_constant.shape[0], 1)), x_constant),keep_x,warn
+    else:
+        return x_constant,keep_x,warn
 
 def _test():
     import doctest


### PR DESCRIPTION
This PR updates all spreg functions to:
- Relax two-dimension requirement for y across functions;
- Adding automatic drop of user added constants in x, including potential regime-specific constants.