### PR TITLE
fix doctest of check_constant

### DIFF
--- a/spreg/user_output.py
+++ b/spreg/user_output.py
@@ -607,7 +607,7 @@ def check_constant(x,name_x=None,just_rem=False):
     >>> X.append(db.by_col("INC"))
     >>> X.append(db.by_col("HOVAL"))
     >>> X = np.array(X).T
-    >>> x_constant,_ = check_constant(X)
+    >>> x_constant,name_x,warn = check_constant(X)
     >>> x_constant.shape
     (49, 3)
 


### PR DESCRIPTION
This PR is to fix the doctest of [`check_constant`](https://github.com/pysal/spreg/blob/master/spreg/user_output.py#L582) function. The returned value is [a tuple of length 3]( https://github.com/pysal/spreg/blob/master/spreg/user_output.py#L638) instead of 2.

I noticed there is not a unittest module for [`user_output.py`](https://github.com/pysal/spreg/blob/master/spreg/user_output.py). It might make sense to have one so that this type of change can be captured.