### PR TITLE
Fixing a bug in the printing of results of Chow Test in ML_Lag_Regimes

### DIFF
--- a/spreg/ml_lag_regimes.py
+++ b/spreg/ml_lag_regimes.py
@@ -318,7 +318,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         set_warn(self, warn)
         name_x = USER.set_name_x(name_x, x_constant, constant=True)
 
-        self.name_x_r = name_x + [USER.set_name_yend_sp(name_y)]
+        self.name_x_r = USER.set_name_x(name_x, x_constant) + [USER.set_name_yend_sp(name_y)]
         self.method = method
         self.epsilon = epsilon
         self.name_regimes = USER.set_name_ds(name_regimes)


### PR DESCRIPTION
There was a bug in the way the list with variables' names for the regimes was created in ML_Lag_Regimes. This bug resulted in the summary_output skipping the first variable's name instead of 'Constant' when printing the results of the Chow test when any of the coefficients was constant across regimes.