### PR TITLE
add panel diagnostics to API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -123,3 +123,8 @@ Diagnostic tests are useful for identifying model fit, sufficiency, and specific
     spreg.surLMe
     spreg.surLMlag
     spreg.constant_check
+    spreg.panel_LMlag
+    spreg.panel_LMerror
+    spreg.panel_rLMlag
+    spreg.panel_rLMerror
+    spreg.panel_Hausman


### PR DESCRIPTION
I noticed a handful of the panel diagnostics were missing from the docs so this includes them