### PR TITLE
Updates for spreg 1.4

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -47,7 +47,7 @@
        
        - name: install bleeding edge libpysal (only Ubuntu / Python 3.9)
          shell: bash -l {0}
-         run: pip install git+https://github.com/pysal/libpysal.git@master
+         run: pip install git+https://github.com/pysal/libpysal.git@main
          if: matrix.os == 'ubuntu-latest' && contains(matrix.environment-file, 'DEV')
        
        - name: run tests - bash

--- a/spreg/diagnostics_sp.py
+++ b/spreg/diagnostics_sp.py
@@ -18,7 +18,6 @@ __all__ = ["LMtests", "MoranRes", "AKtest"]
 
 
 class LMtests:
-
     """
     Lagrange Multiplier tests. Implemented as presented in :cite:`Anselin1996a`
 
@@ -142,7 +141,6 @@ class LMtests:
 
 
 class MoranRes:
-
     """
     Moran's I for spatial autocorrelation in residuals from OLS regression
 
@@ -396,7 +394,6 @@ class AKtest:
 
 
 class spDcache:
-
     """
     Helper class to compute reusable pieces in the spatial diagnostics module
     ...
@@ -669,7 +666,7 @@ def get_vI(ols, w, ei, spDcache):
     B = spDcache.AB[1]
     trB = np.sum(B.diagonal()) * 4.0
     vi = (w.n ** 2 / (w.s0 ** 2 * (w.n - ols.k) * (w.n - ols.k + 2.0))) * (
-        w.s1 + 2.0 * trA2 - trB - ((2.0 * (spDcache.trA ** 2)) / (w.n - ols.k))
+            w.s1 + 2.0 * trA2 - trB - ((2.0 * (spDcache.trA ** 2)) / (w.n - ols.k))
     )
     return vi
 
@@ -716,9 +713,6 @@ def akTest(iv, w, spDcache):
     p           : float
                   P-value of the test
 
-    ToDo:
-        * Code in as Nancy
-        * Compare both
     """
     mi = get_mI(iv, w, spDcache)
     # Phi2
@@ -729,6 +723,42 @@ def akTest(iv, w, spDcache):
     ak = w.n * mi ** 2 / phi2
     pval = chisqprob(ak, 1)
     return (mi, ak[0][0], pval[0][0])
+
+
+def comfac_test(lambd, beta, gamma, vm):
+    """
+    Computes the Spatial Common Factor Hypothesis test as shown in Anselin (1988, p. 226-229)
+
+    Parameters
+    ----------
+
+    lambd       : float
+                  Spatial autoregressive coefficient (as in lambd*Wy)
+    beta        : array
+                  Coefficients of the exogenous (not spatially lagged) variables, without the constant (as in X*beta)
+    gamma       : array
+                  coefficients of the spatially lagged exogenous variables (as in WX*gamma)
+    vm          : array
+                  Variance-covariance matrix of the coefficients
+                  Obs. Needs to match the order of theta' = [beta', gamma', lambda]
+
+    Returns
+    -------
+    W       : float
+              Wald statistic
+    pvalue  : float
+              P value for Wald statistic calculated as a Chi sq. distribution
+              with k-1 degrees of freedom
+
+    """
+    g = lambd * beta + gamma
+    G = np.vstack((lambd * np.eye(beta.shape[0]), np.eye(beta.shape[0]), beta.T))
+
+    GVGi = la.inv(np.dot(G.T, np.dot(vm, G)))
+    W = np.dot(g.T, np.dot(GVGi, g))[0][0]
+    df = G.shape[1]
+    pvalue = chisqprob(W, df)
+    return W, pvalue
 
 
 def _test():

--- a/spreg/diagnostics_sur.py
+++ b/spreg/diagnostics_sur.py
@@ -221,7 +221,7 @@ def surLMlag(n_eq, WS, bigy, bigX, bigE, bigYP, sig, varb):
 
     """
     # Score
-    Y = np.hstack((bigy[r]) for r in range(n_eq))
+    Y = np.hstack([bigy[r] for r in range(n_eq)])
     WY = WS * Y
     EWY = np.dot(bigE.T, WY)
     sigi = la.inv(sig)

--- a/spreg/error_sp.py
+++ b/spreg/error_sp.py
@@ -9,23 +9,16 @@ __author__ = "Luc Anselin luc.anselin@asu.edu, \
 import numpy as np
 from numpy import linalg as la
 from . import ols as OLS
-from libpysal.weights.spatial_lag import lag_spatial
-from .utils import power_expansion, set_endog, iter_msg, sp_att
-from .utils import (
-    get_A1_hom,
-    get_A2_hom,
-    get_A1_het,
-    optim_moments,
-    get_spFilter,
-    get_lags,
-    _moments2eqs,
-)
-from .utils import spdot, RegressionPropsY, set_warn
+from .utils import set_endog, sp_att, optim_moments, get_spFilter, get_lags, spdot, RegressionPropsY, set_warn
 from . import twosls as TSLS
 from . import user_output as USER
-from . import summary_output as SUMMARY
+import pandas as pd
+from .output import output, _spat_pseudo_r2
+from .error_sp_het import GM_Error_Het, GM_Endog_Error_Het, GM_Combo_Het
+from .error_sp_hom import GM_Error_Hom, GM_Endog_Error_Hom, GM_Combo_Hom
 
-__all__ = ["GM_Error", "GM_Endog_Error", "GM_Combo"]
+
+__all__ = ["GMM_Error", "GM_Error", "GM_Endog_Error", "GM_Combo"]
 
 
 class BaseGM_Error(RegressionPropsY):
@@ -138,6 +131,9 @@ class GM_Error(BaseGM_Error):
                    independent (exogenous) variable, excluding the constant
     w            : pysal W object
                    Spatial weights object (always needed)
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the SDEM type.
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results
@@ -149,9 +145,13 @@ class GM_Error(BaseGM_Error):
                    Name of weights matrix for use in output
     name_ds      : string
                    Name of dataset for use in output
+    latex        : boolean
+                   Specifies if summary is to be printed in latex format
 
     Attributes
     ----------
+    output       : dataframe
+                   regression results pandas dataframe
     summary      : string
                    Summary of regression results and diagnostics (note: use in
                    conjunction with the print command)
@@ -287,7 +287,7 @@ class GM_Error(BaseGM_Error):
     """
 
     def __init__(
-        self, y, x, w, vm=False, name_y=None, name_x=None, name_w=None, name_ds=None
+        self, y, x, w, slx_lags=0, vm=False, name_y=None, name_x=None, name_w=None, name_ds=None, latex=False
     ):
 
         n = USER.check_arrays(y, x)
@@ -295,14 +295,24 @@ class GM_Error(BaseGM_Error):
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
         set_warn(self, warn)
+        
+        self.title = "GM SPATIALLY WEIGHTED LEAST SQUARES"
+        if slx_lags >0:
+            lag_x = get_lags(w, x_constant[:, 1:], slx_lags)
+            x_constant = np.hstack((x_constant, lag_x))
+            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            self.title += " WITH SLX (SDEM)"
+        
         BaseGM_Error.__init__(self, y=y, x=x_constant, w=w.sparse)
-        self.title = "SPATIALLY WEIGHTED LEAST SQUARES"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
         self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_x.append("lambda")
         self.name_w = USER.set_name_w(name_w, w)
-        SUMMARY.GM_Error(reg=self, w=w, vm=vm)
+        self.output = pd.DataFrame(self.name_x, columns=['var_names'])
+        self.output['var_type'] = ['x'] * (len(self.name_x) - 1) + ['lambda']
+        self.output['regime'], self.output['equation'] = (0, 0)
+        output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
 
 class BaseGM_Endog_Error(RegressionPropsY):
@@ -379,7 +389,7 @@ class BaseGM_Endog_Error(RegressionPropsY):
     >>> w.transform='r'
     >>> model = spreg.error_sp.BaseGM_Endog_Error(y, x, yend, q, w=w.sparse)
     >>> np.around(model.betas, decimals=4)
-    array([[82.573 ],
+    array([[82.5723],
            [ 0.581 ],
            [-1.4481],
            [ 0.3499]])
@@ -438,6 +448,9 @@ class GM_Endog_Error(BaseGM_Endog_Error):
                    this should not contain any variables from x)
     w            : pysal W object
                    Spatial weights object (always needed)
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the SDEM type.
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results
@@ -453,9 +466,13 @@ class GM_Endog_Error(BaseGM_Endog_Error):
                    Name of weights matrix for use in output
     name_ds      : string
                    Name of dataset for use in output
+    latex        : boolean
+                   Specifies if summary is to be printed in latex format
 
     Attributes
     ----------
+    output       : dataframe
+                   regression results pandas dataframe
     summary      : string
                    Summary of regression results and diagnostics (note: use in
                    conjunction with the print command)
@@ -603,12 +620,12 @@ class GM_Endog_Error(BaseGM_Endog_Error):
     >>> print(model.name_z)
     ['CONSTANT', 'inc', 'hoval', 'lambda']
     >>> np.around(model.betas, decimals=4)
-    array([[82.573 ],
+    array([[82.5723],
            [ 0.581 ],
            [-1.4481],
            [ 0.3499]])
     >>> np.around(model.std_err, decimals=4)
-    array([16.1381,  1.3545,  0.7862])
+    array([16.1382,  1.3545,  0.7862])
 
     """
 
@@ -619,6 +636,7 @@ class GM_Endog_Error(BaseGM_Endog_Error):
         yend,
         q,
         w,
+        slx_lags=0,
         vm=False,
         name_y=None,
         name_x=None,
@@ -626,6 +644,7 @@ class GM_Endog_Error(BaseGM_Endog_Error):
         name_q=None,
         name_w=None,
         name_ds=None,
+        latex=False,
     ):
 
         n = USER.check_arrays(y, x, yend, q)
@@ -633,8 +652,13 @@ class GM_Endog_Error(BaseGM_Endog_Error):
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
         set_warn(self, warn)
+        self.title = "GM SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES"
+        if slx_lags >0:
+            lag_x = get_lags(w, x_constant[:, 1:], slx_lags)
+            x_constant = np.hstack((x_constant, lag_x))
+            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            self.title += " WITH SLX (SDEM)"        
         BaseGM_Endog_Error.__init__(self, y=y, x=x_constant, w=w.sparse, yend=yend, q=q)
-        self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
         self.name_x = USER.set_name_x(name_x, x_constant)
@@ -644,137 +668,14 @@ class GM_Endog_Error(BaseGM_Endog_Error):
         self.name_q = USER.set_name_q(name_q, q)
         self.name_h = USER.set_name_h(self.name_x, self.name_q)
         self.name_w = USER.set_name_w(name_w, w)
-        SUMMARY.GM_Endog_Error(reg=self, w=w, vm=vm)
+        self.output = pd.DataFrame(self.name_z,
+                                   columns=['var_names'])
+        self.output['var_type'] = ['x'] * len(self.name_x) + ['yend'] * len(self.name_yend) + ['lambda']
+        self.output['regime'], self.output['equation'] = (0, 0)
+        output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
 
-class BaseGM_Combo(BaseGM_Endog_Error):
-
-    """
-    GMM method for a spatial lag and error model, with endogenous variables
-    (note: no consistency checks, diagnostics or constant added); based on
-    Kelejian and Prucha (1998, 1999) :cite:`Kelejian1998` :cite:`Kelejian1999`.
-
-    Parameters
-    ----------
-    y            : array
-                   nx1 array for dependent variable
-    x            : array
-                   Two dimensional array with n rows and one column for each
-                   independent (exogenous) variable, excluding the constant
-    yend         : array
-                   Two dimensional array with n rows and one column for each
-                   endogenous variable
-    q            : array
-                   Two dimensional array with n rows and one column for each
-                   external exogenous variable to use as instruments (note:
-                   this should not contain any variables from x)
-    w            : Sparse matrix
-                   Spatial weights sparse matrix
-    w_lags       : integer
-                   Orders of W to include as instruments for the spatially
-                   lagged dependent variable. For example, w_lags=1, then
-                   instruments are WX; if w_lags=2, then WX, WWX; and so on.
-    lag_q        : boolean
-                   If True, then include spatial lags of the additional
-                   instruments (q).
-
-    Attributes
-    ----------
-    betas        : array
-                   kx1 array of estimated coefficients
-    u            : array
-                   nx1 array of residuals
-    e_filtered   : array
-                   nx1 array of spatially filtered residuals
-    predy        : array
-                   nx1 array of predicted y values
-    n            : integer
-                   Number of observations
-    k            : integer
-                   Number of variables for which coefficients are estimated
-                   (including the constant)
-    y            : array
-                   nx1 array for dependent variable
-    x            : array
-                   Two dimensional array with n rows and one column for each
-                   independent (exogenous) variable, including the constant
-    yend         : array
-                   Two dimensional array with n rows and one column for each
-                   endogenous variable
-    z            : array
-                   nxk array of variables (combination of x and yend)
-    mean_y       : float
-                   Mean of dependent variable
-    std_y        : float
-                   Standard deviation of dependent variable
-    vm           : array
-                   Variance covariance matrix (kxk)
-    sig2         : float
-                   Sigma squared used in computations
-
-    Examples
-    --------
-
-    >>> import numpy as np
-    >>> import libpysal
-    >>> import spreg
-    >>> db = libpysal.io.open(libpysal.examples.get_path('columbus.dbf'),'r')
-    >>> y = np.array(db.by_col("CRIME"))
-    >>> y = np.reshape(y, (49,1))
-    >>> X = []
-    >>> X.append(db.by_col("INC"))
-    >>> X = np.array(X).T
-    >>> w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
-    >>> w.transform = 'r'
-    >>> w_lags = 1
-    >>> yd2, q2 = spreg.set_endog(y, X, w, None, None, w_lags, True)
-    >>> X = np.hstack((np.ones(y.shape),X))
-
-    Example only with spatial lag
-
-    >>> reg = spreg.error_sp.BaseGM_Combo(y, X, yend=yd2, q=q2, w=w.sparse)
-
-    Print the betas
-
-    >>> print(np.around(np.hstack((reg.betas[:-1],np.sqrt(reg.vm.diagonal()).reshape(3,1))),3))
-    [[39.059 11.86 ]
-     [-1.404  0.391]
-     [ 0.467  0.2  ]]
-
-    And lambda
-
-    >>> print('Lamda: ', np.around(reg.betas[-1], 3))
-    Lamda:  [-0.048]
-
-    Example with both spatial lag and other endogenous variables
-
-    >>> X = []
-    >>> X.append(db.by_col("INC"))
-    >>> X = np.array(X).T
-    >>> yd = []
-    >>> yd.append(db.by_col("HOVAL"))
-    >>> yd = np.array(yd).T
-    >>> q = []
-    >>> q.append(db.by_col("DISCBD"))
-    >>> q = np.array(q).T
-    >>> yd2, q2 = spreg.set_endog(y, X, w, yd, q, w_lags, True)
-    >>> X = np.hstack((np.ones(y.shape),X))
-    >>> reg = spreg.error_sp.BaseGM_Combo(y, X, yd2, q2, w=w.sparse)
-    >>> betas = np.array([['CONSTANT'],['INC'],['HOVAL'],['W_CRIME']])
-    >>> print(np.hstack((betas, np.around(np.hstack((reg.betas[:-1], np.sqrt(reg.vm.diagonal()).reshape(4,1))),4))))
-    [['CONSTANT' '50.0944' '14.3593']
-     ['INC' '-0.2552' '0.5667']
-     ['HOVAL' '-0.6885' '0.3029']
-     ['W_CRIME' '0.4375' '0.2314']]
-
-    """
-
-    def __init__(self, y, x, yend=None, q=None, w=None, w_lags=1, lag_q=True):
-
-        BaseGM_Endog_Error.__init__(self, y=y, x=x, w=w, yend=yend, q=q)
-
-
-class GM_Combo(BaseGM_Combo):
+class GM_Combo(BaseGM_Endog_Error):
 
     """
     GMM method for a spatial lag and error model with endogenous variables,
@@ -801,9 +702,13 @@ class GM_Combo(BaseGM_Combo):
                    Orders of W to include as instruments for the spatially
                    lagged dependent variable. For example, w_lags=1, then
                    instruments are WX; if w_lags=2, then WX, WWX; and so on.
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the General Nesting
+                   Spatial Model (GNSM) type.
     lag_q        : boolean
                    If True, then include spatial lags of the additional
-                   instruments (q).
+                   instruments (q)
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results
@@ -819,9 +724,13 @@ class GM_Combo(BaseGM_Combo):
                    Name of weights matrix for use in output
     name_ds      : string
                    Name of dataset for use in output
+    latex        : boolean
+                   Specifies if summary is to be printed in latex format
 
     Attributes
     ----------
+    output       : dataframe
+                   regression results pandas dataframe
     summary      : string
                    Summary of regression results and diagnostics (note: use in
                    conjunction with the print command)
@@ -1015,6 +924,7 @@ class GM_Combo(BaseGM_Combo):
         q=None,
         w=None,
         w_lags=1,
+        slx_lags=0,
         lag_q=True,
         vm=False,
         name_y=None,
@@ -1023,6 +933,7 @@ class GM_Combo(BaseGM_Combo):
         name_q=None,
         name_w=None,
         name_ds=None,
+        latex=False,
     ):
 
         n = USER.check_arrays(y, x, yend, q)
@@ -1030,23 +941,23 @@ class GM_Combo(BaseGM_Combo):
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
         set_warn(self, warn)
-        yend2, q2 = set_endog(y, x_constant[:, 1:], w, yend, q, w_lags, lag_q)
-        BaseGM_Combo.__init__(
-            self,
-            y=y,
-            x=x_constant,
-            w=w.sparse,
-            yend=yend2,
-            q=q2,
-            w_lags=w_lags,
-            lag_q=lag_q,
-        )
+        if slx_lags == 0:
+            yend2, q2 = set_endog(y, x_constant[:, 1:], w, yend, q, w_lags, lag_q)
+        else:
+            yend2, q2, wx = set_endog(y, x_constant[:, 1:], w, yend, q, w_lags, lag_q, slx_lags)
+            x_constant = np.hstack((x_constant, wx))
+
+        BaseGM_Endog_Error.__init__(self, y=y, x=x_constant, w=w.sparse, yend=yend2, q=q2)
+
         self.rho = self.betas[-2]
         self.predy_e, self.e_pred, warn = sp_att(
             w, self.y, self.predy, yend2[:, -1].reshape(self.n, 1), self.rho
         )
         set_warn(self, warn)
-        self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES"
+        self.title = "SPATIALLY WEIGHTED 2SLS - GM-COMBO MODEL"
+        if slx_lags > 0:
+            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            self.title += " WITH SLX (GNSM)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
         self.name_x = USER.set_name_x(name_x, x_constant)
@@ -1058,7 +969,294 @@ class GM_Combo(BaseGM_Combo):
         self.name_q.extend(USER.set_name_q_sp(self.name_x, w_lags, self.name_q, lag_q))
         self.name_h = USER.set_name_h(self.name_x, self.name_q)
         self.name_w = USER.set_name_w(name_w, w)
-        SUMMARY.GM_Combo(reg=self, w=w, vm=vm)
+        self.output = pd.DataFrame(self.name_z,
+                                   columns=['var_names'])
+        self.output['var_type'] = ['x'] * len(self.name_x) + ['yend'] * (len(self.name_yend) - 1) + ['rho', 'lambda']
+        self.output['regime'], self.output['equation'] = (0, 0)
+        self.other_top = _spat_pseudo_r2(self)
+        output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
+
+
+class GMM_Error(GM_Error, GM_Endog_Error, GM_Combo, GM_Error_Het, GM_Endog_Error_Het, 
+               GM_Combo_Het, GM_Error_Hom, GM_Endog_Error_Hom, GM_Combo_Hom):
+
+    """
+    Wrapper function to call any of the GMM methods for a spatial error model available in spreg
+
+    Parameters
+    ----------
+    y            : array
+                   nx1 array for dependent variable
+    x            : array
+                   Two dimensional array with n rows and one column for each
+                   independent (exogenous) variable, excluding the constant
+    w            : pysal W object
+                   Spatial weights object (always needed)
+    yend         : array
+                   Two dimensional array with n rows and one column for each
+                   endogenous variable (if any)
+    q            : array
+                   Two dimensional array with n rows and one column for each
+                   external exogenous variable to use as instruments (if any)
+                   (note: this should not contain any variables from x)
+    estimator    : string
+                   Choice of estimator to be used. Options are: 'het', which
+                   is robust to heteroskedasticity, 'hom', which assumes
+                   homoskedasticity, and 'kp98', which does not provide
+                   inference on the spatial parameter for the error term.
+    add_wy       : boolean
+                   If True, then a spatial lag of the dependent variable is included.           
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the SDEM or GNSM type.             
+    vm           : boolean
+                   If True, include variance-covariance matrix in summary
+                   results
+    name_y       : string
+                   Name of dependent variable for use in output
+    name_x       : list of strings
+                   Names of independent variables for use in output
+    name_w       : string
+                   Name of weights matrix for use in output
+    name_yend    : list of strings
+                   Names of endogenous variables for use in output
+    name_q       : list of strings
+                   Names of instruments for use in output                   
+    name_ds      : string
+                   Name of dataset for use in output
+    latex        : boolean
+                   Specifies if summary is to be printed in latex format
+    **kwargs     : keywords
+                   Additional arguments to pass on to the estimators. 
+                   See the specific functions for details on what can be used.
+
+    Attributes
+    ----------
+    output       : dataframe
+                   regression results pandas dataframe
+    summary      : string
+                   Summary of regression results and diagnostics (note: use in
+                   conjunction with the print command)
+    betas        : array
+                   kx1 array of estimated coefficients
+    u            : array
+                   nx1 array of residuals
+    e_filtered   : array
+                   nx1 array of spatially filtered residuals
+    predy        : array
+                   nx1 array of predicted y values
+    n            : integer
+                   Number of observations
+    k            : integer
+                   Number of variables for which coefficients are estimated
+                   (including the constant)
+    y            : array
+                   nx1 array for dependent variable
+    x            : array
+                   Two dimensional array with n rows and one column for each
+                   independent (exogenous) variable, including the constant
+    mean_y       : float
+                   Mean of dependent variable
+    std_y        : float
+                   Standard deviation of dependent variable
+    pr2          : float
+                   Pseudo R squared (squared correlation between y and ypred)
+    vm           : array
+                   Variance covariance matrix (kxk)
+    sig2         : float
+                   Sigma squared used in computations
+    std_err      : array
+                   1xk array of standard errors of the betas
+    z_stat       : list of tuples
+                   z statistic; each tuple contains the pair (statistic,
+                   p-value), where each is a float
+    name_y       : string
+                   Name of dependent variable for use in output
+    name_x       : list of strings
+                   Names of independent variables for use in output
+    name_w       : string
+                   Name of weights matrix for use in output
+    name_ds      : string
+                   Name of dataset for use in output
+    title        : string
+                   Name of the regression method used
+    name_yend    : list of strings (optional)
+                    Names of endogenous variables for use in output
+    name_z       : list of strings (optional)
+                    Names of exogenous and endogenous variables for use in
+                    output
+    name_q       : list of strings (optional)
+                    Names of external instruments
+    name_h       : list of strings (optional)
+                    Names of all instruments used in ouput                   
+    
+
+    Examples
+    --------
+
+    We first need to import the needed modules, namely numpy to convert the
+    data we read into arrays that ``spreg`` understands and ``libpysal`` to
+    handle the weights and file management.
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from libpysal.examples import load_example
+
+    Open data on NCOVR US County Homicides (3085 areas) using libpysal.io.open().
+    This is the DBF associated with the NAT shapefile.  Note that
+    libpysal.io.open() also reads data in CSV format; since the actual class
+    requires data to be passed in as numpy arrays, the user can read their
+    data in using any method.
+
+    >>> nat = load_example('Natregimes')
+    >>> db = libpysal.io.open(nat.get_path("natregimes.dbf"),'r')
+
+    Extract the HR90 column (homicide rates in 1990) from the DBF file and make it the
+    dependent variable for the regression. Note that PySAL requires this to be
+    an numpy array of shape (n, 1) as opposed to the also common shape of (n, )
+    that other packages accept.
+
+    >>> y_var = 'HR90'
+    >>> y = np.array([db.by_col(y_var)]).reshape(3085,1)
+
+    Extract UE90 (unemployment rate) and PS90 (population structure) vectors from
+    the DBF to be used as independent variables in the regression. Other variables
+    can be inserted by adding their names to x_var, such as x_var = ['Var1','Var2','...]
+    Note that PySAL requires this to be an nxj numpy array, where j is the
+    number of independent variables (not including a constant). By default
+    this model adds a vector of ones to the independent variables passed in.
+
+    >>> x_var = ['PS90','UE90']
+    >>> x = np.array([db.by_col(name) for name in x_var]).T
+
+     Since we want to run a spatial error model, we need to specify
+    the spatial weights matrix that includes the spatial configuration of the
+    observations. To do that, we can open an already existing gal file or
+    create a new one. In this case, we will create one from ``NAT.shp``.
+
+    >>> w = libpysal.weights.Rook.from_shapefile(nat.get_path("natregimes.shp"))
+
+    Unless there is a good reason not to do it, the weights have to be
+    row-standardized so every row of the matrix sums to one. Among other
+    things, this allows to interpret the spatial lag of a variable as the
+    average value of the neighboring observations. In PySAL, this can be
+    easily performed in the following way:
+
+    >>> w.transform = 'r'
+
+    The GMM_Error class can run error models and SARAR models, that is a spatial lag+error model.
+    In this example we will run a simple version of the latter, where we have the
+    spatial effects as well as exogenous variables. Since it is a spatial
+    model, we have to pass in the weights matrix. If we want to
+    have the names of the variables printed in the output summary, we will
+    have to pass them in as well, although this is optional.
+
+    >>> from spreg import GMM_Error
+    >>> model = GMM_Error(y, x, w=w, add_wy=True, name_y=y_var, name_x=x_var, name_ds='NAT')
+
+    Once we have run the model, we can explore a little bit the output. The
+    regression object we have created has many attributes so take your time to
+    discover them.
+
+    >>> print(model.output)
+      var_names coefficients   std_err    zt_stat      prob
+    0  CONSTANT     2.176007  1.115807   1.950165  0.051156
+    1      PS90     1.108054  0.207964   5.328096       0.0
+    2      UE90     0.664362  0.061294   10.83893       0.0
+    3    W_HR90    -0.066539  0.154395  -0.430964  0.666494
+    4    lambda     0.765087   0.04268  17.926245       0.0
+
+    This class also allows the user to run a spatial lag+error model with the
+    extra feature of including non-spatial endogenous regressors. This means
+    that, in addition to the spatial lag and error, we consider some of the
+    variables on the right-hand side of the equation as endogenous and we
+    instrument for this. In this case we consider RD90 (resource deprivation)
+    as an endogenous regressor.  We use FP89 (families below poverty)
+    for this and hence put it in the instruments parameter, 'q'.
+
+    >>> yd_var = ['RD90']
+    >>> yd = np.array([db.by_col(name) for name in yd_var]).T
+    >>> q_var = ['FP89']
+    >>> q = np.array([db.by_col(name) for name in q_var]).T
+
+    And then we can run and explore the model analogously to the previous combo:
+
+    >>> model = GMM_Error(y, x, yend=yd, q=q, w=w, add_wy=True, name_y=y_var, name_x=x_var, name_yend=yd_var, name_q=q_var, name_ds='NAT')
+    >>> print(model.output)
+      var_names coefficients   std_err    zt_stat      prob
+    0  CONSTANT      5.44035  0.560476   9.706652       0.0
+    1      PS90     1.427042    0.1821   7.836572       0.0
+    2      UE90    -0.075224  0.050031  -1.503544  0.132699
+    3      RD90     3.316266  0.261269  12.692924       0.0
+    4    W_HR90     0.200314  0.057433   3.487777  0.000487
+    5    lambda     0.136933  0.070098   1.953457  0.050765
+
+    The class also allows for estimating a GNS model by adding spatial lags of the exogenous variables, using the argument slx_lags:
+
+    >>> model = GMM_Error(y, x, w=w, add_wy=True, slx_lags=1, name_y=y_var, name_x=x_var, name_ds='NAT')
+    >>> print(model.output)
+      var_names coefficients   std_err   zt_stat      prob
+    0  CONSTANT    -0.554756  0.551765  -1.00542  0.314695
+    1      PS90      1.09369  0.225895  4.841583  0.000001
+    2      UE90     0.697393  0.082744  8.428291       0.0
+    3    W_PS90    -1.533378  0.396651 -3.865811  0.000111
+    4    W_UE90    -1.107944   0.33523 -3.305028   0.00095
+    5    W_HR90     1.529277  0.389354  3.927728  0.000086
+    6    lambda    -0.917928  0.079569 -11.53625       0.0
+
+
+    """
+
+    def __init__(
+        self, y, x, w, yend=None, q=None, estimator='het', add_wy=False, slx_lags=0, vm=False, name_y=None, name_x=None, name_w=None, name_yend=None,
+        name_q=None, name_ds=None, latex=False, **kwargs):
+
+        if estimator == 'het':
+            if yend is None and not add_wy:
+                GM_Error_Het.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
+                                      name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            elif yend is not None and not add_wy:
+                GM_Endog_Error_Het.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            elif add_wy:
+                GM_Combo_Het.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            else:
+                set_warn(self, 'Combination of arguments passed to GMM_Error not allowed. Using default arguments instead.')
+                GM_Error_Het.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
+                                      name_w=name_w, name_ds=name_ds, latex=latex)
+        elif estimator == 'hom':
+            if yend is None and not add_wy:
+                GM_Error_Hom.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
+                                      name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            elif yend is not None and not add_wy:
+                GM_Endog_Error_Hom.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            elif add_wy:
+                GM_Combo_Hom.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            else:
+                set_warn(self, 'Combination of arguments passed to GMM_Error not allowed. Using default arguments instead.')
+                GM_Error_Hom.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
+                                      name_w=name_w, name_ds=name_ds, latex=latex)
+        elif estimator == 'kp98':
+            if yend is None and not add_wy:
+                GM_Error.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
+                                      name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            elif yend is not None and not add_wy:
+                GM_Endog_Error.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            elif add_wy:
+                GM_Combo.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+            else:
+                set_warn(self, 'Combination of arguments passed to GMM_Error not allowed. Using default arguments instead.')
+                GM_Error.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
+                                      name_w=name_w, name_ds=name_ds, latex=latex)
+        else:
+            set_warn(self, 'Combination of arguments passed to GMM_Error not allowed. Using default arguments instead.')
+            GM_Error_Het.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
+                                    name_w=name_w, name_ds=name_ds, latex=latex)
 
 
 def _momentsGM_Error(w, u):
@@ -1103,16 +1301,30 @@ def _test():
 if __name__ == "__main__":
 
     _test()
-    import libpysal
-    import numpy as np
 
-    dbf = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
-    y = np.array([dbf.by_col("HOVAL")]).T
-    names_to_extract = ["INC", "CRIME"]
-    x = np.array([dbf.by_col(name) for name in names_to_extract]).T
-    w = libpysal.io.open(libpysal.examples.get_path("columbus.gal"), "r").read()
-    w.transform = "r"
-    model = GM_Error(
-        y, x, w, name_y="hoval", name_x=["income", "crime"], name_ds="columbus"
-    )
-    print(model.summary)
+    import numpy as np
+    import libpysal
+
+    db = libpysal.io.open(libpysal.examples.get_path('columbus.dbf'),'r')
+    y = np.array(db.by_col("HOVAL"))
+    y = np.reshape(y, (49,1))
+    X = []
+    X.append(db.by_col("INC"))
+    X = np.array(X).T
+    yd = []
+    yd.append(db.by_col("CRIME"))
+    yd = np.array(yd).T
+    q = []
+    q.append(db.by_col("DISCBD"))
+    q = np.array(q).T
+
+    w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+    w.transform = 'r'
+    #reg = GM_Error(y, X, w=w, name_x=['inc'], name_y='hoval', name_ds='columbus', vm=True)
+    #reg = GM_Endog_Error(y, X, yd, q, w=w, name_x=['inc'], name_y='hoval', name_yend=['crime'],
+    #                         name_q=['discbd'], name_ds='columbus',vm=True)
+    reg = GM_Combo(y, X, yd, q, w=w, name_x=['inc'], name_y='hoval', name_yend=['crime'], name_q=['discbd'],
+                       name_ds='columbus', vm=True)
+
+    print(reg.output)
+    print(reg.summary)

--- a/spreg/error_sp_hom.py
+++ b/spreg/error_sp_hom.py
@@ -10,14 +10,14 @@ from scipy import sparse as SP
 import numpy as np
 from numpy import linalg as la
 from . import ols as OLS
-from libpysal.weights.spatial_lag import lag_spatial
-from .utils import power_expansion, set_endog, iter_msg, sp_att
+from .utils import set_endog, iter_msg, sp_att
 from .utils import get_A1_hom, get_A2_hom, get_A1_het, optim_moments
-from .utils import get_spFilter, get_lags, _moments2eqs
+from .utils import get_spFilter, get_lags
 from .utils import spdot, RegressionPropsY, set_warn
 from . import twosls as TSLS
 from . import user_output as USER
-from . import summary_output as SUMMARY
+import pandas as pd
+from .output import output, _spat_pseudo_r2, _summary_iteration
 
 __all__ = ["GM_Error_Hom", "GM_Endog_Error_Hom", "GM_Combo_Hom"]
 
@@ -178,6 +178,9 @@ class GM_Error_Hom(BaseGM_Error_Hom):
                    independent (exogenous) variable, excluding the constant
     w            : pysal W object
                    Spatial weights object
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the SDEM type.
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from :cite:`Arraiz2010`.
                    Note: epsilon provides an additional stop condition.
@@ -201,10 +204,13 @@ class GM_Error_Hom(BaseGM_Error_Hom):
                    Name of weights matrix for use in output
     name_ds      : string
                    Name of dataset for use in output
-
+    latex        : boolean
+                   Specifies if summary is to be printed in latex format
 
     Attributes
     ----------
+    output       : dataframe
+                   regression results pandas dataframe
     summary      : string
                    Summary of regression results and diagnostics (note: use in
                    conjunction with the print command)
@@ -341,6 +347,7 @@ class GM_Error_Hom(BaseGM_Error_Hom):
         y,
         x,
         w,
+        slx_lags=0,
         max_iter=1,
         epsilon=0.00001,
         A1="hom_sc",
@@ -349,6 +356,7 @@ class GM_Error_Hom(BaseGM_Error_Hom):
         name_x=None,
         name_w=None,
         name_ds=None,
+        latex=False,
     ):
 
         n = USER.check_arrays(y, x)
@@ -356,6 +364,12 @@ class GM_Error_Hom(BaseGM_Error_Hom):
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
         set_warn(self, warn)
+        self.title = "GM SPATIALLY WEIGHTED LEAST SQUARES (HOM)"
+        if slx_lags >0:
+            lag_x = get_lags(w, x_constant[:, 1:], slx_lags)
+            x_constant = np.hstack((x_constant, lag_x))
+            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            self.title += " WITH SLX (SDEM)"        
         BaseGM_Error_Hom.__init__(
             self,
             y=y,
@@ -365,13 +379,17 @@ class GM_Error_Hom(BaseGM_Error_Hom):
             max_iter=max_iter,
             epsilon=epsilon,
         )
-        self.title = "SPATIALLY WEIGHTED LEAST SQUARES (HOM)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
         self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_x.append("lambda")
         self.name_w = USER.set_name_w(name_w, w)
-        SUMMARY.GM_Error_Hom(reg=self, w=w, vm=vm)
+        self.A1 = A1
+        self.output = pd.DataFrame(self.name_x, columns=['var_names'])
+        self.output['var_type'] = ['x'] * (len(self.name_x) - 1) + ['lambda']
+        self.output['regime'], self.output['equation'] = (0, 0)
+        self.other_top = _summary_iteration(self)
+        output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
 
 class BaseGM_Endog_Error_Hom(RegressionPropsY):
@@ -564,6 +582,9 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
                    this should not contain any variables from x)
     w            : pysal W object
                    Spatial weights object
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the SDEM type.                   
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from
                    :cite:`Arraiz2010`. Note: epsilon provides an additional stop condition.
@@ -591,9 +612,13 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
                    Name of weights matrix for use in output
     name_ds      : string
                    Name of dataset for use in output
+    latex        : boolean
+                   Specifies if summary is to be printed in latex format
 
     Attributes
     ----------
+    output       : dataframe
+                   regression results pandas dataframe
     summary      : string
                    Summary of regression results and diagnostics (note: use in
                    conjunction with the print command)
@@ -769,6 +794,7 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
         yend,
         q,
         w,
+        slx_lags=0,
         max_iter=1,
         epsilon=0.00001,
         A1="hom_sc",
@@ -779,6 +805,7 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
         name_q=None,
         name_w=None,
         name_ds=None,
+        latex=False,
     ):
 
         n = USER.check_arrays(y, x, yend, q)
@@ -786,6 +813,12 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
         set_warn(self, warn)
+        self.title = "GM SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES (HOM)"
+        if slx_lags > 0:
+            lag_x = get_lags(w, x_constant[:, 1:], slx_lags)
+            x_constant = np.hstack((x_constant, lag_x))
+            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            self.title += " WITH SLX (SDEM)"
         BaseGM_Endog_Error_Hom.__init__(
             self,
             y=y,
@@ -797,7 +830,6 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
             max_iter=max_iter,
             epsilon=epsilon,
         )
-        self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES (HOM)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
         self.name_x = USER.set_name_x(name_x, x_constant)
@@ -807,7 +839,13 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
         self.name_q = USER.set_name_q(name_q, q)
         self.name_h = USER.set_name_h(self.name_x, self.name_q)
         self.name_w = USER.set_name_w(name_w, w)
-        SUMMARY.GM_Endog_Error_Hom(reg=self, w=w, vm=vm)
+        self.A1 = A1
+        self.output = pd.DataFrame(self.name_z,
+                                   columns=['var_names'])
+        self.output['var_type'] = ['x'] * len(self.name_x) + ['yend'] * len(self.name_yend) + ['lambda']
+        self.output['regime'], self.output['equation'] = (0, 0)
+        self.other_top = _summary_iteration(self)
+        output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
 
 class BaseGM_Combo_Hom(BaseGM_Endog_Error_Hom):
@@ -1007,6 +1045,10 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
                    Orders of W to include as instruments for the spatially
                    lagged dependent variable. For example, w_lags=1, then
                    instruments are WX; if w_lags=2, then WX, WWX; and so on.
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the General Nesting
+                   Spatial Model (GNSM) type.
     lag_q        : boolean
                    If True, then include spatial lags of the additional 
                    instruments (q).
@@ -1038,9 +1080,13 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
                    Name of weights matrix for use in output
     name_ds      : string
                    Name of dataset for use in output
+    latex        : boolean
+                   Specifies if summary is to be printed in latex format
 
     Attributes
     ----------
+    output       : dataframe
+                   regression results pandas dataframe
     summary      : string
                    Summary of regression results and diagnostics (note: use in
                    conjunction with the print command)
@@ -1232,6 +1278,7 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
         q=None,
         w=None,
         w_lags=1,
+        slx_lags=0,
         lag_q=True,
         max_iter=1,
         epsilon=0.00001,
@@ -1243,6 +1290,7 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
         name_q=None,
         name_w=None,
         name_ds=None,
+        latex=False,
     ):
 
         n = USER.check_arrays(y, x, yend, q)
@@ -1250,7 +1298,11 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
         set_warn(self, warn)
-        yend2, q2 = set_endog(y, x_constant[:, 1:], w, yend, q, w_lags, lag_q)
+        if slx_lags == 0:
+            yend2, q2 = set_endog(y, x_constant[:, 1:], w, yend, q, w_lags, lag_q)
+        else:
+            yend2, q2, wx = set_endog(y, x_constant[:, 1:], w, yend, q, w_lags, lag_q, slx_lags)
+            x_constant = np.hstack((x_constant, wx))
         BaseGM_Combo_Hom.__init__(
             self,
             y=y,
@@ -1269,7 +1321,10 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
             w, self.y, self.predy, yend2[:, -1].reshape(self.n, 1), self.rho
         )
         set_warn(self, warn)
-        self.title = "SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES (HOM)"
+        self.title = "SPATIALLY WEIGHTED 2SLS- GM-COMBO MODEL (HOM)"
+        if slx_lags > 0:
+            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            self.title += " WITH SLX (GNSM)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
         self.name_x = USER.set_name_x(name_x, x_constant)
@@ -1281,8 +1336,14 @@ class GM_Combo_Hom(BaseGM_Combo_Hom):
         self.name_q.extend(USER.set_name_q_sp(self.name_x, w_lags, self.name_q, lag_q))
         self.name_h = USER.set_name_h(self.name_x, self.name_q)
         self.name_w = USER.set_name_w(name_w, w)
-        SUMMARY.GM_Combo_Hom(reg=self, w=w, vm=vm)
-
+        self.A1 = A1
+        self.output = pd.DataFrame(self.name_z,
+                                   columns=['var_names'])
+        self.output['var_type'] = ['x'] * len(self.name_x) + ['yend'] * (len(self.name_yend) - 1) + ['rho', 'lambda']
+        self.output['regime'], self.output['equation'] = (0, 0)
+        self.other_top = _spat_pseudo_r2(self)
+        self.other_top += _summary_iteration(self)
+        output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
 # Functions
 
@@ -1514,5 +1575,31 @@ def _test():
 
 
 if __name__ == "__main__":
-
     _test()
+
+    import numpy as np
+    import libpysal
+
+    db = libpysal.io.open(libpysal.examples.get_path('columbus.dbf'),'r')
+    y = np.array(db.by_col("HOVAL"))
+    y = np.reshape(y, (49,1))
+    X = []
+    X.append(db.by_col("INC"))
+    X = np.array(X).T
+    yd = []
+    yd.append(db.by_col("CRIME"))
+    yd = np.array(yd).T
+    q = []
+    q.append(db.by_col("DISCBD"))
+    q = np.array(q).T
+
+    w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+    w.transform = 'r'
+    #reg = GM_Error_Hom(y, X, w=w, name_x=['inc'], name_y='hoval', name_ds='columbus', vm=True)
+    #reg = GM_Endog_Error_Hom(y, X, yd, q, w=w, name_x=['inc'], name_y='hoval', name_yend=['crime'],
+    #                         name_q=['discbd'], name_ds='columbus',vm=True)
+    reg = GM_Combo_Hom(y, X, yd, q, w=w, name_x=['inc'], name_y='hoval', name_yend=['crime'], name_q=['discbd'],
+                       name_ds='columbus', vm=True)
+
+    print(reg.output)
+    print(reg.summary)

--- a/spreg/ml_error.py
+++ b/spreg/ml_error.py
@@ -501,7 +501,7 @@ class ML_Error(BaseML_Error):
         )
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x)
+        self.name_x = USER.set_name_x(name_x, x_constant)
         self.name_x.append("lambda")
         self.name_w = USER.set_name_w(name_w, w)
         self.aic = DIAG.akaike(reg=self)

--- a/spreg/ml_lag_regimes.py
+++ b/spreg/ml_lag_regimes.py
@@ -7,12 +7,14 @@ __author__ = "Luc Anselin luc.anselin@asu.edu, Pedro V. Amaral pedro.amaral@asu.
 import numpy as np
 from . import regimes as REGI
 from . import user_output as USER
-from . import summary_output as SUMMARY
 from . import diagnostics as DIAG
 import multiprocessing as mp
 from .ml_lag import BaseML_Lag
-from .utils import set_warn
+from .utils import set_warn, get_lags
 from platform import system
+import pandas as pd
+from .output import output, _nonspat_top, _spat_pseudo_r2
+
 
 __all__ = ["ML_Lag_Regimes"]
 
@@ -55,6 +57,9 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                    if 'LU', LU sparse matrix decomposition
     epsilon      : float
                    tolerance criterion in mimimize_scalar function and inverse_product
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the Spatial Durbin type.                   
     regime_lag_sep: boolean
                     If True, the spatial parameter for spatial lag is also
                     computed according to different regimes. If False (default),
@@ -76,9 +81,13 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                    Name of dataset for use in output
     name_regimes : string
                    Name of regimes variable for use in output
+    latex        : boolean
+                   Specifies if summary is to be printed in latex format
 
     Attributes
     ----------
+    output       : dataframe
+                   regression results pandas dataframe
     summary      : string
                    Summary of regression results and diagnostics (note: use in
                    conjunction with the print command)
@@ -297,8 +306,8 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         cols2regi="all",
         method="full",
         epsilon=0.0000001,
+        slx_lags=0,
         regime_lag_sep=False,
-        regime_err_sep=False,
         cores=False,
         vm=False,
         name_y=None,
@@ -306,6 +315,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         name_w=None,
         name_ds=None,
         name_regimes=None,
+        latex=False,
     ):
 
         n = USER.check_arrays(y, x)
@@ -317,6 +327,11 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         x_constant, name_x, warn = USER.check_constant(x, name_x, just_rem=True)
         set_warn(self, warn)
         name_x = USER.set_name_x(name_x, x_constant, constant=True)
+
+        if slx_lags >0:
+            lag_x = get_lags(w, x_constant, slx_lags)
+            x_constant = np.hstack((x_constant, lag_x))
+            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
 
         self.name_x_r = USER.set_name_x(name_x, x_constant) + [USER.set_name_yend_sp(name_y)]
         self.method = method
@@ -364,6 +379,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                 w_i,
                 w,
                 regi_ids,
+                slx_lags=slx_lags,
                 cores=cores,
                 cols2regi=cols2regi,
                 method=method,
@@ -374,17 +390,19 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                 name_regimes=self.name_regimes,
                 name_w=name_w,
                 name_ds=name_ds,
+                latex=latex,
             )
         else:
             # if regime_lag_sep == True:
             #    w = REGI.w_regimes_union(w, w_i, self.regimes_set)
-            x, self.name_x = REGI.Regimes_Frame.__init__(
+            x, self.name_x, x_rlist = REGI.Regimes_Frame.__init__(
                 self,
                 x_constant,
                 regimes,
                 constant_regi,
                 cols2regi=cols2regi[:-1],
                 names=name_x,
+                rlist=True
             )
             self.name_x.append("_Global_" + USER.set_name_yend_sp(name_y))
             BaseML_Lag.__init__(self, y=y, x=x, w=w, method=method, epsilon=epsilon)
@@ -395,13 +413,17 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
             self.aic = DIAG.akaike(reg=self)
             self.schwarz = DIAG.schwarz(reg=self)
             self.regime_lag_sep = regime_lag_sep
-            self.title = (
-                "MAXIMUM LIKELIHOOD SPATIAL LAG - REGIMES"
-                + " (METHOD = "
-                + method
-                + ")"
-            )
-            SUMMARY.ML_Lag(reg=self, w=w, vm=vm, spat_diag=False, regimes=True)
+            self.output = pd.DataFrame(self.name_x, columns=['var_names'])
+            self.output['var_type'] = ['x'] * (len(self.name_x) - 1) + ['rho']
+            self.output['regime'] = x_rlist+['_Global']
+            self.output['equation'] = 0
+            self.other_top = _spat_pseudo_r2(self)
+            self.other_top += _nonspat_top(self, ml=True)
+            if slx_lags == 0:
+                self.title = ("MAXIMUM LIKELIHOOD SPATIAL LAG - REGIMES"+ " (METHOD = "+ method+ ")")
+            else:
+                self.title = ("MAXIMUM LIKELIHOOD SPATIAL DURBIN - REGIMES"+ " (METHOD = "+ method+ ")")
+            output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
     def ML_Lag_Regimes_Multi(
         self,
@@ -410,6 +432,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         w_i,
         w,
         regi_ids,
+        slx_lags,
         cores,
         cols2regi,
         method,
@@ -420,8 +443,9 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         name_regimes,
         name_w,
         name_ds,
+        latex,
     ):
-        #        pool = mp.Pool(cores)
+        #pool = mp.Pool(cores)
         results_p = {}
         """
         for r in self.regimes_set:
@@ -445,6 +469,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                         regi_ids,
                         r,
                         w_i[r],
+                        slx_lags,
                         method,
                         epsilon,
                         name_ds,
@@ -462,6 +487,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                         regi_ids,
                         r,
                         w_i[r],
+                        slx_lags,
                         method,
                         epsilon,
                         name_ds,
@@ -496,6 +522,7 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         results = {}
         self.name_y, self.name_x = [], []
         counter = 0
+        self.output = pd.DataFrame(columns=['var_names', 'var_type', 'regime', 'equation'])
         for r in self.regimes_set:
             """
             if is_win:
@@ -528,12 +555,16 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
             ] = results[r].e_pred
             self.name_y += results[r].name_y
             self.name_x += results[r].name_x
+            results[r].other_top = _spat_pseudo_r2(results[r])
+            results[r].other_top += _nonspat_top(results[r], ml=True)
+            results[r].other_mid = ""
+            self.output = pd.concat([self.output, pd.DataFrame({'var_names': results[r].name_x,
+                                                                'var_type': ['x'] * (len(results[r].name_x) - 1) + ['rho'],
+                                                                'regime': r, 'equation': r})], ignore_index=True)
             counter += 1
         self.multi = results
         self.chow = REGI.Chow(self)
-        SUMMARY.ML_Lag_multi(
-            reg=self, multireg=self.multi, vm=vm, spat_diag=False, regimes=True, w=w
-        )
+        output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
 
 def _work(
@@ -542,6 +573,7 @@ def _work(
     regi_ids,
     r,
     w_r,
+    slx_lags,
     method,
     epsilon,
     name_ds,
@@ -553,13 +585,10 @@ def _work(
     y_r = y[regi_ids[r]]
     x_r = x[regi_ids[r]]
     model = BaseML_Lag(y_r, x_r, w_r, method=method, epsilon=epsilon)
-    model.title = (
-        "MAXIMUM LIKELIHOOD SPATIAL LAG - REGIME "
-        + str(r)
-        + " (METHOD = "
-        + method
-        + ")"
-    )
+    if slx_lags == 0:
+        model.title = ("MAXIMUM LIKELIHOOD SPATIAL LAG - REGIME "+ str(r)+ " (METHOD = "+ method+ ")")
+    else:
+        model.title = ("MAXIMUM LIKELIHOOD SPATIAL DURBIN - REGIME "+ str(r)+ " (METHOD = "+ method+ ")")
     model.name_ds = name_ds
     model.name_y = "%s_%s" % (str(r), name_y)
     model.name_x = ["%s_%s" % (str(r), i) for i in name_x]
@@ -583,16 +612,16 @@ def _test():
 if __name__ == "__main__":
     _test()
     import numpy as np
-    import libpysal
+    import libpysal as ps
 
-    db = libpysal.io.open(libpysal.examples.get_path("baltim.dbf"), "r")
+    db = ps.io.open(ps.examples.get_path("baltim.dbf"), "r")
     ds_name = "baltim.dbf"
     y_name = "PRICE"
     y = np.array(db.by_col(y_name)).T
     y.shape = (len(y), 1)
     x_names = ["NROOM", "NBATH", "PATIO", "FIREPL", "AC", "GAR", "AGE", "LOTSZ", "SQFT"]
     x = np.array([db.by_col(var) for var in x_names]).T
-    ww = ps.open(ps.examples.get_path("baltim_q.gal"))
+    ww = ps.io.open(ps.examples.get_path("baltim_q.gal"))
     w = ww.read()
     ww.close()
     w_name = "baltim_q.gal"
@@ -610,7 +639,9 @@ if __name__ == "__main__":
         name_w=w_name,
         name_ds=ds_name,
         regime_lag_sep=True,
+        regime_err_sep=False,
         constant_regi="many",
         name_regimes="CITCOU",
     )
+    print(mllag.output)
     print(mllag.summary)

--- a/spreg/output.py
+++ b/spreg/output.py
@@ -1,0 +1,476 @@
+"""Internal helper files for user output."""
+
+__author__ = "Luc Anselin, Pedro V. Amaral"
+
+import textwrap as TW
+import numpy as np
+import pandas as pd
+from . import diagnostics as diagnostics
+from . import diagnostics_tsls as diagnostics_tsls
+from . import diagnostics_sp as diagnostics_sp
+
+__all__ = []
+
+###############################################################################
+############### Primary functions for running summary diagnostics #############
+###############################################################################
+
+def output(reg, vm, other_end=False, robust=False, latex=False):
+    strSummary = output_start(reg)
+    for eq in reg.output['equation'].unique():
+        try:
+            reg.multi[eq].__summary = {}
+            strSummary, reg.multi[eq] = out_part_top(strSummary, reg, eq)
+        except:
+            eq = None
+            strSummary, reg = out_part_top(strSummary, reg, eq)
+        strSummary, reg = out_part_middle(strSummary, reg, robust, m=eq)
+    strSummary, reg = out_part_end(strSummary, reg, vm, other_end, m=eq)
+    reg.summary = strSummary
+    reg.output.sort_values(by=['equation', 'regime'], inplace=True)
+    reg.output.drop(['var_type', 'regime', 'equation'], axis=1, inplace=True)
+
+def output_start(reg):
+    reg.__summary = {}
+    strSummary = "REGRESSION RESULTS\n"
+    strSummary += "------------------\n"
+    reg.output = reg.output.assign(coefficients=[None] * len(reg.output), std_err=[None] * len(reg.output),
+                                   zt_stat=[None] * len(reg.output), prob=[None] * len(reg.output))
+    return strSummary
+
+def out_part_top(strSummary, reg, m):
+    # Top part of summary output.
+    # m = None for single models, m = 1,2,3... for multiple equation models
+    if m == None:
+        _reg = reg  # _reg = local object with regression results
+    else:
+        _reg = reg.multi[m]  # _reg = local object with equation specific regression results
+    title = "\nSUMMARY OF OUTPUT: " + _reg.title + "\n"
+    strSummary += title
+    strSummary += "-" * (len(title) - 2) + "\n"
+    strSummary += "%-20s:%12s\n" % ("Data set", _reg.name_ds)
+    try:
+        strSummary += "%-20s:%12s\n" % ("Weights matrix", _reg.name_w)
+    except:
+        pass
+
+    strSummary += "%-20s:%12s                %-22s:%12d\n" % (
+        "Dependent Variable",
+        _reg.name_y,
+        "Number of Observations",
+        _reg.n,
+    )
+
+    strSummary += "%-20s:%12.4f                %-22s:%12d\n" % (
+        "Mean dependent var",
+        _reg.mean_y,
+        "Number of Variables",
+        _reg.k,
+    )
+    strSummary += "%-20s:%12.4f                %-22s:%12d\n" % (
+        "S.D. dependent var",
+        _reg.std_y,
+        "Degrees of Freedom",
+        _reg.n - _reg.k,
+    )
+
+    _reg.std_err = diagnostics.se_betas(_reg)
+    if 'OLS' in reg.__class__.__name__:
+        _reg.t_stat = diagnostics.t_stat(_reg)
+        _reg.r2 = diagnostics.r2(_reg)
+        _reg.ar2 = diagnostics.ar2(_reg)
+        strSummary += "%-20s:%12.4f\n%-20s:%12.4f\n" % (
+            "R-squared",
+            _reg.r2,
+            "Adjusted R-squared",
+            _reg.ar2,
+        )
+        _reg.__summary["summary_zt"] = "t"
+
+    else:
+        _reg.z_stat = diagnostics.t_stat(_reg, z_stat=True)
+        _reg.pr2 = diagnostics_tsls.pr2_aspatial(_reg)
+        strSummary += "%-20s:%12.4f\n" % ("Pseudo R-squared", _reg.pr2)
+        _reg.__summary["summary_zt"] = "z"
+
+    try:  # Adding additional top part if there is one
+        strSummary += _reg.other_top
+    except:
+        pass
+
+    return (strSummary, _reg)
+
+def out_part_middle(strSummary, reg, robust, m=None):
+    # Middle part of summary output.
+    # m = None for single models, m = 1,2,3... for multiple equation models
+    if m==None:
+        _reg = reg #_reg = local object with regression results
+        m = reg.output['equation'].unique()[0]
+    else:
+        _reg = reg.multi[m] #_reg = local object with equation specific regression results
+    coefs = pd.DataFrame(_reg.betas, columns=['coefficients'])
+    coefs['std_err'] = pd.DataFrame(_reg.std_err)
+    try:
+        coefs = pd.concat([coefs, pd.DataFrame(_reg.z_stat, columns=['zt_stat', 'prob'])], axis=1)
+    except AttributeError:
+        coefs = pd.concat([coefs, pd.DataFrame(_reg.t_stat, columns=['zt_stat', 'prob'])], axis=1)
+    coefs.index = reg.output[reg.output['equation'] == m].index
+    reg.output.update(coefs)
+    strSummary += "\n"
+    if robust:
+        if robust == "white":
+            strSummary += "White Standard Errors\n"
+        elif robust == "hac":
+            strSummary += "HAC Standard Errors; Kernel Weights: " + _reg.name_gwk + "\n"
+        elif robust == "ogmm":
+            strSummary += "Optimal GMM used to estimate the coefficients and the variance-covariance matrix\n"            
+    strSummary += "------------------------------------------------------------------------------------\n"
+    strSummary += (
+            "            Variable     Coefficient       Std.Error     %1s-Statistic     Probability\n"
+            % (_reg.__summary["summary_zt"])
+    )
+    strSummary += "------------------------------------------------------------------------------------\n"
+    m_output = reg.output[reg.output['equation'] == m]
+    for row in m_output.iloc[np.lexsort((m_output.index, m_output['regime']))].itertuples():
+        try:
+            strSummary += "%20s    %12.5f    %12.5f    %12.5f    %12.5f\n" % (
+                row.var_names,
+                row.coefficients,
+                row.std_err,
+                row.zt_stat,
+                row.prob
+            )
+        except TypeError:  # special case for models that do not have inference on the lambda term
+            strSummary += "%20s    %12.5f    \n" % (
+                row.var_names,
+                row.coefficients
+            )
+    strSummary += "------------------------------------------------------------------------------------\n"
+
+    try:  # Adding info on instruments if they are present
+        name_q = _reg.name_q
+        name_yend = _reg.name_yend
+        insts = "Instruments: "
+        for name in sorted(name_q):
+            insts += name + ", "
+        text_wrapper = TW.TextWrapper(width=76, subsequent_indent="             ")
+        insts = text_wrapper.fill(insts[:-2])
+        insts += "\n"
+        inst2 = "Instrumented: "
+        for name in sorted(name_yend):
+            inst2 += name + ", "
+        text_wrapper = TW.TextWrapper(width=76, subsequent_indent="             ")
+        inst2 = text_wrapper.fill(inst2[:-2])
+        inst2 += "\n"
+        inst2 += insts
+        strSummary += inst2
+    except:
+        pass
+
+    try:  # Adding info on regimes if they are present
+        strSummary += ("Regimes variable: %s\n" % _reg.name_regimes)
+        strSummary += _summary_chow(_reg)  # If local regimes present, compute Chow test.
+    except:
+        pass
+
+    try:  # Adding local warning if there is one
+        if _reg.warning:
+            strSummary += _reg.warning
+    except:
+        pass
+
+    try:  # Adding other middle part if there are any
+        strSummary += _reg.other_mid
+    except:
+        pass
+
+    return (strSummary, reg)
+
+def out_part_end(strSummary, reg, vm, other_end, m=None):
+    if m is not None:
+        strSummary += "------------------------------------------------------------------------------------\n"
+        try:  # Adding global warning if there is one
+            strSummary += reg.warning
+        except:
+            pass
+        strSummary += "\nGLOBAL DIAGNOSTICS\n"
+        try:  # Adding global Chow test if there is one
+            strSummary += _summary_chow(reg)
+        except:
+            pass
+    if other_end:
+        strSummary += other_end
+    if vm:
+        strSummary += _summary_vm(reg)
+    strSummary += "================================ END OF REPORT ====================================="
+    return (strSummary, reg)
+
+def _summary_chow(reg):
+    sum_text = "\nREGIMES DIAGNOSTICS - CHOW TEST"
+    name_x_r = reg.name_x_r
+    joint, regi = reg.chow.joint, reg.chow.regi
+    sum_text += "\n                 VARIABLE        DF        VALUE           PROB\n"
+    if reg.cols2regi == "all":
+        names_chow = name_x_r[1:]
+    else:
+        names_chow = [name_x_r[1:][i] for i in np.where(reg.cols2regi)[0]]
+    if reg.constant_regi == "many":
+        names_chow = ["CONSTANT"] + names_chow
+
+    if 'lambda' in reg.output.var_type.values:
+        if reg.output.var_type.value_counts()['lambda'] > 1:
+            names_chow += ["lambda"]
+
+    reg.output_chow = pd.DataFrame()
+    reg.output_chow['var_names'] = names_chow
+    reg.output_chow['df'] = reg.nr - 1
+    reg.output_chow = pd.concat([reg.output_chow, pd.DataFrame(regi, columns=['value', 'prob'])], axis=1)
+    reg.output_chow = pd.concat([reg.output_chow, pd.DataFrame([{'var_names': 'Global test',
+                                              'df':  reg.kr * (reg.nr - 1),
+                                              'value': joint[0], 'prob': joint[1]}])], ignore_index=True)
+    for row in reg.output_chow.itertuples():
+        sum_text += "%25s        %2d    %12.3f        %9.4f\n" % (
+            row.var_names,
+            row.df,
+            row.value,
+            row.prob
+        )
+
+    return sum_text
+
+
+def _spat_diag_out(reg, w, type, moran=False):
+    strSummary = "\nDIAGNOSTICS FOR SPATIAL DEPENDENCE\n"
+    if not moran:
+        strSummary += (
+            "TEST                              DF       VALUE           PROB\n"
+        )
+    else:
+        strSummary += (
+            "TEST                           MI/DF       VALUE           PROB\n"
+        )
+
+    cache = diagnostics_sp.spDcache(reg, w)
+    if type == "yend":
+        mi, ak, ak_p = diagnostics_sp.akTest(reg, w, cache)
+        reg.ak_test = ak, ak_p
+        strSummary += "%-27s      %2d    %12.3f        %9.4f\n" % (
+            "Anselin-Kelejian Test",
+            1,
+            reg.ak_test[0],
+            reg.ak_test[1],
+        )
+    elif type == "ols":
+        lm_tests = diagnostics_sp.LMtests(reg, w)
+        reg.lm_error = lm_tests.lme
+        reg.lm_lag = lm_tests.lml
+        reg.rlm_error = lm_tests.rlme
+        reg.rlm_lag = lm_tests.rlml
+        reg.lm_sarma = lm_tests.sarma
+        if moran:
+            moran_res = diagnostics_sp.MoranRes(reg, w, z=True)
+            reg.moran_res = moran_res.I, moran_res.zI, moran_res.p_norm
+            strSummary += "%-27s  %8.4f     %9.3f        %9.4f\n" % (
+                "Moran's I (error)",
+                reg.moran_res[0],
+                reg.moran_res[1],
+                reg.moran_res[2],
+            )
+        strSummary += "%-27s      %2d    %12.3f        %9.4f\n" % (
+            "Lagrange Multiplier (lag)",
+            1,
+            reg.lm_lag[0],
+            reg.lm_lag[1],
+        )
+        strSummary += "%-27s      %2d    %12.3f        %9.4f\n" % (
+            "Robust LM (lag)",
+            1,
+            reg.rlm_lag[0],
+            reg.rlm_lag[1],
+        )
+        strSummary += "%-27s      %2d    %12.3f        %9.4f\n" % (
+            "Lagrange Multiplier (error)",
+            1,
+            reg.lm_error[0],
+            reg.lm_error[1],
+        )
+        strSummary += "%-27s      %2d    %12.3f        %9.4f\n" % (
+            "Robust LM (error)",
+            1,
+            reg.rlm_error[0],
+            reg.rlm_error[1],
+        )
+        strSummary += "%-27s      %2d    %12.3f        %9.4f\n\n" % (
+            "Lagrange Multiplier (SARMA)",
+            2,
+            reg.lm_sarma[0],
+            reg.lm_sarma[1],
+        )
+    return strSummary
+
+def _nonspat_top(reg, ml=False):
+    if not ml:
+        reg.sig2ML = reg.sig2n
+        reg.f_stat = diagnostics.f_stat(reg)
+        reg.logll = diagnostics.log_likelihood(reg)
+        reg.aic = diagnostics.akaike(reg)
+        reg.schwarz = diagnostics.schwarz(reg)
+
+        strSummary = "%-20s:%12.6g                %-22s:%12.4f\n" % (
+            "Sum squared residual", reg.utu, "F-statistic", reg.f_stat[0],)
+        strSummary += "%-20s:%12.3f                %-22s:%12.4g\n" % (
+            "Sigma-square",
+            reg.sig2,
+            "Prob(F-statistic)",
+            reg.f_stat[1],
+        )
+        strSummary += "%-20s:%12.3f                %-22s:%12.3f\n" % (
+            "S.E. of regression",
+            np.sqrt(reg.sig2),
+            "Log likelihood",
+            reg.logll,
+        )
+        strSummary += "%-20s:%12.3f                %-22s:%12.3f\n" % (
+            "Sigma-square ML",
+            reg.sig2ML,
+            "Akaike info criterion",
+            reg.aic,
+        )
+        strSummary += "%-20s:%12.4f                %-22s:%12.3f\n" % (
+            "S.E of regression ML",
+            np.sqrt(reg.sig2ML),
+            "Schwarz criterion",
+            reg.schwarz,
+        )
+    else:
+        strSummary = "%-20s:%12.4f\n" % (
+            "Log likelihood",
+            reg.logll,
+        )
+        strSummary += "%-20s:%12.4f                %-22s:%12.3f\n" % (
+            "Sigma-square ML",
+            reg.sig2,
+            "Akaike info criterion",
+            reg.aic,
+        )
+        strSummary += "%-20s:%12.4f                %-22s:%12.3f\n" % (
+            "S.E of regression",
+            np.sqrt(reg.sig2),
+            "Schwarz criterion",
+            reg.schwarz,
+        )
+
+    return strSummary
+
+def _nonspat_mid(reg, white_test=False):
+    # compute diagnostics
+    reg.mulColli = diagnostics.condition_index(reg)
+    reg.jarque_bera = diagnostics.jarque_bera(reg)
+    reg.breusch_pagan = diagnostics.breusch_pagan(reg)
+    reg.koenker_bassett = diagnostics.koenker_bassett(reg)
+
+    if white_test:
+        reg.white = diagnostics.white(reg)
+
+    strSummary = "\nREGRESSION DIAGNOSTICS\n"
+    if reg.mulColli:
+        strSummary += "MULTICOLLINEARITY CONDITION NUMBER %16.3f\n\n" % (reg.mulColli)
+    strSummary += "TEST ON NORMALITY OF ERRORS\n"
+    strSummary += "TEST                             DF        VALUE           PROB\n"
+    strSummary += "%-27s      %2d  %14.3f        %9.4f\n\n" % (
+        "Jarque-Bera",
+        reg.jarque_bera["df"],
+        reg.jarque_bera["jb"],
+        reg.jarque_bera["pvalue"],
+    )
+    strSummary += "DIAGNOSTICS FOR HETEROSKEDASTICITY\n"
+    strSummary += "RANDOM COEFFICIENTS\n"
+    strSummary += "TEST                             DF        VALUE           PROB\n"
+    strSummary += "%-27s      %2d    %12.3f        %9.4f\n" % (
+        "Breusch-Pagan test",
+        reg.breusch_pagan["df"],
+        reg.breusch_pagan["bp"],
+        reg.breusch_pagan["pvalue"],
+    )
+    strSummary += "%-27s      %2d    %12.3f        %9.4f\n" % (
+        "Koenker-Bassett test",
+        reg.koenker_bassett["df"],
+        reg.koenker_bassett["kb"],
+        reg.koenker_bassett["pvalue"],
+    )
+    try:
+        if reg.white:
+            strSummary += "\nSPECIFICATION ROBUST TEST\n"
+            if len(reg.white) > 3:
+                strSummary += reg.white + "\n"
+            else:
+                strSummary += (
+                    "TEST                             DF        VALUE           PROB\n"
+                )
+                strSummary += "%-27s      %2d    %12.3f        %9.4f\n" % (
+                    "White",
+                    reg.white["df"],
+                    reg.white["wh"],
+                    reg.white["pvalue"],
+                )
+    except:
+        pass
+    return strSummary
+
+def _spat_pseudo_r2(reg):
+    if np.abs(reg.rho) < 1:
+        reg.pr2_e = diagnostics_tsls.pr2_spatial(reg)
+        strSummary = "%-20s:  %5.4f\n" % ("Spatial Pseudo R-squared", reg.pr2_e)
+    else:
+        strSummary =  "Spatial Pseudo R-squared: omitted due to rho outside the boundary (-1, 1).\n"
+    return strSummary
+
+def _summary_vm(reg):
+    strVM = "\n"
+    strVM += "COEFFICIENTS VARIANCE MATRIX\n"
+    strVM += "----------------------------\n"
+    try:
+        for name in reg.name_z:
+            strVM += "%12s" % (name)
+    except:
+        for name in reg.name_x:
+            strVM += "%12s" % (name)
+    strVM += "\n"
+    nrow = reg.vm.shape[0]
+    ncol = reg.vm.shape[1]
+    for i in range(nrow):
+        for j in range(ncol):
+            strVM += "%12.6f" % (reg.vm[i][j])
+        strVM += "\n"
+    return strVM
+
+def _summary_iteration(reg):
+    """Reports the number of iterations computed and the type of estimator used for hom and het models."""
+    try:
+        niter = reg.niter
+    except:
+        niter = reg.iteration
+
+    txt = "%-20s:%12s\n" % ("N. of iterations", niter)
+
+    try:
+        if reg.step1c:
+            step1c = "Yes"
+        else:
+            step1c = "No"
+        txt = txt[:-1] + "                %-22s:%12s\n" % (
+            "Step1c computed",
+            step1c,
+        )
+    except:
+       pass
+
+    try:
+        txt = txt[:-1] + "                %-22s:%12s" % (
+            "A1 type: ",
+            reg.A1,
+        )
+    except:
+        pass
+
+    return txt

--- a/spreg/output.py
+++ b/spreg/output.py
@@ -16,6 +16,8 @@ __all__ = []
 ###############################################################################
 
 def output(reg, vm, other_end=False, robust=False, latex=False):
+    if latex:
+        print("Warning: Latex output not implemented yet. Using standard output instead.")
     strSummary = output_start(reg)
     for eq in reg.output['equation'].unique():
         try:

--- a/spreg/sur_error.py
+++ b/spreg/sur_error.py
@@ -553,7 +553,7 @@ class BaseSURerrorML:
             bigE = sur_resids(self.bigy, self.bigX, b1)
             res = minimize(
                 clik,
-                lam,
+                np.array(lam).flatten(),
                 args=(self.n, self.n2, self.n_eq, bigE, I, WS),
                 method="L-BFGS-B",
                 bounds=lambdabounds,
@@ -1119,7 +1119,7 @@ if __name__ == "__main__":
         bigy0,
         bigX0,
         w,
-        regimes=regimes,
+        #regimes=regimes,
         name_bigy=bigyvars0,
         name_bigX=bigXvars0,
         name_w="natqueen",

--- a/spreg/sur_utils.py
+++ b/spreg/sur_utils.py
@@ -290,7 +290,9 @@ def sur_dict2mat(dicts):
 
     """
     n_dicts = len(dicts.keys())
-    mat = np.vstack((dicts[t] for t in range(n_dicts)))
+    #mat = np.vstack((dicts[t] for t in range(n_dicts)))
+    mat = np.vstack([dicts[t] for t in range(n_dicts)])
+
     return mat
 
 
@@ -392,10 +394,11 @@ def sur_est(bigXX, bigXy, bigE, bigK):
         for t in range(n_eq):
             sxy = sxy + sigi[r, t] * bigXy[(r, t)]
         sigiXy[r] = sxy
-    xsigy = np.vstack((sigiXy[t] for t in range(n_eq)))
-    xsigx = np.vstack(
-        ((np.hstack(sigiXX[(r, t)] for t in range(n_eq))) for r in range(n_eq))
-    )
+    #xsigy = np.vstack((sigiXy[t] for t in range(n_eq)))
+    xsigy = np.vstack(tuple(sigiXy[t] for t in range(n_eq)))
+    #xsigx = np.vstack(((np.hstack(sigiXX[(r, t)] for t in range(n_eq))) for r in range(n_eq)))
+    array_lists = [[sigiXX[(r, t)] for t in range(n_eq)] for r in range(n_eq)]
+    xsigx = np.vstack([np.hstack(arr_list) for arr_list in array_lists])    
     varb = la.inv(xsigx)
     beta = np.dot(varb, xsigy)
     bSUR = sur_mat2dict(beta, bigK)
@@ -423,7 +426,9 @@ def sur_resids(bigy, bigX, beta):
 
     """
     n_eq = len(bigy.keys())
-    bigE = np.hstack((bigy[r] - spdot(bigX[r], beta[r])) for r in range(n_eq))
+    #bigE = np.hstack((bigy[r] - spdot(bigX[r], beta[r])) for r in range(n_eq))
+    bigE = np.hstack(tuple(bigy[r] - spdot(bigX[r], beta[r]) for r in range(n_eq)))
+
     return bigE
 
 
@@ -449,7 +454,9 @@ def sur_predict(bigy, bigX, beta):
 
     """
     n_eq = len(bigy.keys())
-    bigYP = np.hstack(spdot(bigX[r], beta[r]) for r in range(n_eq))
+    #bigYP = np.hstack(spdot(bigX[r], beta[r]) for r in range(n_eq))
+    bigYP = np.hstack([spdot(bigX[r], beta[r]) for r in range(n_eq)])
+
     return bigYP
 
 

--- a/spreg/tests/test_error_sp.py
+++ b/spreg/tests/test_error_sp.py
@@ -6,129 +6,104 @@ from spreg import error_sp as SP
 from spreg import utils
 from libpysal.common import RTOL
 
-
 class TestBaseGMError(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = SP.BaseGM_Error(self.y, self.X, self.w.sparse)
-        betas = np.array([[47.94371455], [0.70598088], [-0.55571746], [0.37230161]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([27.4739775])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([52.9930255])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 27.4739775])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 52.9930255])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        e = np.array([31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        predy = np.array([52.9930255])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        e = np.array([ 31.89620319])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        predy = np.array([ 52.9930255])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                [1.51884943e02, -5.37622793e00, -1.86970286e00],
-                [-5.37622793e00, 2.48972661e-01, 5.26564244e-02],
-                [-1.86970286e00, 5.26564244e-02, 3.18930650e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
-
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 class TestGMError(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = SP.GM_Error(self.y, self.X, self.w)
-        betas = np.array([[47.94371455], [0.70598088], [-0.55571746], [0.37230161]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([27.4739775])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([52.9930255])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 27.4739775])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 52.9930255])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        e = np.array([31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        predy = np.array([52.9930255])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        e = np.array([ 31.89620319])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        predy = np.array([ 52.9930255])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                [1.51884943e02, -5.37622793e00, -1.86970286e00],
-                [-5.37622793e00, 2.48972661e-01, 5.26564244e-02],
-                [-1.86970286e00, 5.26564244e-02, 3.18930650e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3495097406012179
-        np.testing.assert_allclose(reg.pr2, pr2)
-        std_err = np.array([12.32416094, 0.4989716, 0.1785863])
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                [3.89022140e00, 1.00152805e-04],
-                [1.41487186e00, 1.57106070e-01],
-                [-3.11175868e00, 1.85976455e-03],
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-
+        np.testing.assert_allclose(reg.pr2,pr2)
+        std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 class TestBaseGMEndogError(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         yd = []
         yd.append(db.by_col("CRIME"))
         self.yd = np.array(yd).T
@@ -136,55 +111,50 @@ class TestBaseGMEndogError(unittest.TestCase):
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
         self.w = weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
-        self.w.transform = "r"
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = SP.BaseGM_Endog_Error(self.y, self.X, self.yd, self.q, self.w.sparse)
-        betas = np.array([[55.36095292], [0.46411479], [-0.66883535], [0.38989939]])
-        # raising a warning causes a failure...
-        print("Running reduced precision test in L120 of test_error_sp.py")
-        np.testing.assert_allclose(reg.betas, betas, RTOL + 0.0001)
-        u = np.array([26.55951566])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e = np.array([31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        predy = np.array([53.9074875])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
+        #raising a warning causes a failure...
+        print('Running reduced precision test in L120 of test_error_sp.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL+.0001)
+        u = np.array([ 26.55951566])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        e = np.array([ 31.23925425])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        predy = np.array([ 53.9074875])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        yend = np.array([15.72598])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.z[0], z, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.   ,  19.531])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        yend = np.array([  15.72598])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
-        # std_y
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
+        #std_y
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        # vm
-        vm = np.array(
-            [
-                [5.29158422e02, -1.57833675e01, -8.38021080e00],
-                [-1.57833675e01, 5.40235041e-01, 2.31120327e-01],
-                [-8.38021080e00, 2.31120327e-01, 1.44977385e-01],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        #vm
+        vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
+       [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
+       [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 192.50022721929574
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
-
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 class TestGMEndogError(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
@@ -194,180 +164,105 @@ class TestGMEndogError(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = SP.GM_Endog_Error(self.y, self.X, self.yd, self.q, self.w)
-        betas = np.array([[55.36095292], [0.46411479], [-0.66883535], [0.38989939]])
-        print("Running reduced precision test in L175 of test_error_sp.py")
-        np.testing.assert_allclose(reg.betas, betas, RTOL + 0.0001)
-        u = np.array([26.55951566])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e = np.array([31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        predy = np.array([53.9074875])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
+        print('Running reduced precision test in L175 of test_error_sp.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL +.0001)
+        u = np.array([ 26.55951566])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        e = np.array([ 31.23925425])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        predy = np.array([ 53.9074875])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        yend = np.array([15.72598])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.z[0], z, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.   ,  19.531])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        yend = np.array([  15.72598])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                [5.29158422e02, -1.57833675e01, -8.38021080e00],
-                [-1.57833675e01, 5.40235041e-01, 2.31120327e-01],
-                [-8.38021080e00, 2.31120327e-01, 1.44977385e-01],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
+       [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
+       [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.346472557570858
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         sig2 = 192.50022721929574
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
-        std_err = np.array([23.003401, 0.73500657, 0.38075777])
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                [2.40664208, 0.01609994],
-                [0.63144305, 0.52775088],
-                [-1.75659016, 0.07898769],
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-
-
-class TestBaseGMCombo(unittest.TestCase):
-    def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
-        y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
-        X = []
-        X.append(db.by_col("INC"))
-        X.append(db.by_col("CRIME"))
-        self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
-    def test_model(self):
-        # Only spatial lag
-        yd2, q2 = utils.set_endog(self.y, self.X, self.w, None, None, 1, True)
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
-        reg = SP.BaseGM_Combo(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse)
-        betas = np.array(
-            [[57.61123461], [0.73441314], [-0.59459416], [-0.21762921], [0.54732051]]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([25.57932637])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e_filtered = np.array([31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0], e_filtered, RTOL)
-        predy = np.array([54.88767663])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
-        n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
-        k = 4
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        yend = np.array([35.4585005])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        z = np.array([1.0, 19.531, 15.72598, 35.4585005])
-        np.testing.assert_allclose(reg.z[0], z, RTOL)
-        my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
-        sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array([5.22438365e02, 2.38012873e-01, 3.20924172e-02, 2.15753599e-01])
-        np.testing.assert_allclose(np.diag(reg.vm), vm, RTOL)
-        sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
+        std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 
 class TestGMCombo(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
     def test_model(self):
         # Only spatial lag
         reg = SP.GM_Combo(self.y, self.X, w=self.w)
-        e_reduced = np.array([28.18617481])
-        np.testing.assert_allclose(reg.e_pred[0], e_reduced, RTOL)
-        predy_e = np.array([52.28082782])
-        np.testing.assert_allclose(reg.predy_e[0], predy_e, RTOL)
-        betas = np.array(
-            [[57.61123515], [0.73441313], [-0.59459416], [-0.21762921], [0.54732051]]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([25.57932637])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e_filtered = np.array([31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0], e_filtered, RTOL)
-        predy = np.array([54.88767685])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        e_reduced = np.array([ 28.18617481])
+        np.testing.assert_allclose(reg.e_pred[0],e_reduced,RTOL)
+        predy_e = np.array([ 52.28082782])
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,RTOL)
+        betas = np.array([[ 57.61123515],[  0.73441313], [ -0.59459416], [ -0.21762921], [  0.54732051]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 25.57932637])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        e_filtered = np.array([ 31.65374945])
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
+        predy = np.array([ 54.88767685])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 4
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        yend = np.array([35.4585005])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        z = np.array([1.0, 19.531, 15.72598, 35.4585005])
-        np.testing.assert_allclose(reg.z[0], z, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        yend = np.array([  35.4585005])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy)
-        vm = np.array([5.22438333e02, 2.38012875e-01, 3.20924173e-02, 2.15753579e-01])
-        np.testing.assert_allclose(np.diag(reg.vm), vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy)
+        vm = np.array([  5.22438333e+02,   2.38012875e-01,   3.20924173e-02,
+         2.15753579e-01])
+        np.testing.assert_allclose(np.diag(reg.vm),vm,RTOL)
         sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3018280166937799
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.3561355586759414
-        np.testing.assert_allclose(reg.pr2_e, pr2_e, RTOL)
-        std_err = np.array([22.85692222, 0.48786559, 0.17914356, 0.46449318])
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                [2.52051597e00, 1.17182922e-02],
-                [1.50535954e00, 1.32231664e-01],
-                [-3.31909311e00, 9.03103123e-04],
-                [-4.68530506e-01, 6.39405261e-01],
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
+        std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/spreg/tests/test_error_sp_sparse.py
+++ b/spreg/tests/test_error_sp_sparse.py
@@ -5,133 +5,108 @@ import scipy
 from scipy import sparse
 from spreg import utils
 from spreg import error_sp as SP
-from libpysal.common import RTOL
-
+from libpysal.common import RTOL 
 
 class TestBaseGMError(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = SP.BaseGM_Error(self.y, self.X, self.w.sparse)
-        betas = np.array([[47.94371455], [0.70598088], [-0.55571746], [0.37230161]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([27.4739775])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([52.9930255])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 27.4739775])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 52.9930255])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x.toarray()[0], x, RTOL)
-        e = np.array([31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        predy = np.array([52.9930255])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
+        e = np.array([ 31.89620319])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        predy = np.array([ 52.9930255])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                [1.51884943e02, -5.37622793e00, -1.86970286e00],
-                [-5.37622793e00, 2.48972661e-01, 5.26564244e-02],
-                [-1.86970286e00, 5.26564244e-02, 3.18930650e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
-
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 class TestGMError(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = SP.GM_Error(self.y, self.X, self.w)
-        betas = np.array([[47.94371455], [0.70598088], [-0.55571746], [0.37230161]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([27.4739775])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([52.9930255])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 27.4739775])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 52.9930255])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x.toarray()[0], x, RTOL)
-        e = np.array([31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        predy = np.array([52.9930255])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
+        e = np.array([ 31.89620319])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        predy = np.array([ 52.9930255])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                [1.51884943e02, -5.37622793e00, -1.86970286e00],
-                [-5.37622793e00, 2.48972661e-01, 5.26564244e-02],
-                [-1.86970286e00, 5.26564244e-02, 3.18930650e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3495097406012179
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
-        std_err = np.array([12.32416094, 0.4989716, 0.1785863])
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                [3.89022140e00, 1.00152805e-04],
-                [1.41487186e00, 1.57106070e-01],
-                [-3.11175868e00, 1.85976455e-03],
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
+        std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 class TestBaseGMEndogError(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
         yd = []
         yd.append(db.by_col("CRIME"))
@@ -139,57 +114,50 @@ class TestBaseGMEndogError(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = SP.BaseGM_Endog_Error(self.y, self.X, self.yd, self.q, self.w.sparse)
-        betas = np.array([[55.36095292], [0.46411479], [-0.66883535], [0.38989939]])
-        print("Running reduced-precision test in L125 of test_error_sp_sparse.py")
-        np.testing.assert_allclose(reg.betas, betas, RTOL + 0.0001)
-        u = np.array([26.55951566])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e = np.array([31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        predy = np.array([53.9074875])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
+        print('Running reduced-precision test in L125 of test_error_sp_sparse.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL + .0001)
+        u = np.array([ 26.55951566])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        e = np.array([ 31.23925425])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        predy = np.array([ 53.9074875])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_allclose(reg.x.toarray()[0], x, RTOL)
-        yend = np.array([15.72598])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.z.toarray()[0], z, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.   ,  19.531])
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
+        yend = np.array([  15.72598])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.z.toarray()[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
-        # std_y
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
+        #std_y
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        # vm
-        vm = np.array(
-            [
-                [529.15840986, -15.78336736, -8.38021053],
-                [-15.78336736, 0.54023504, 0.23112032],
-                [-8.38021053, 0.23112032, 0.14497738],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        #vm
+        vm = np.array([[ 529.15840986,  -15.78336736,   -8.38021053],
+       [ -15.78336736,    0.54023504,    0.23112032],
+       [  -8.38021053,    0.23112032,    0.14497738]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 192.5002
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
-
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 class TestGMEndogError(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
@@ -200,185 +168,109 @@ class TestGMEndogError(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = SP.GM_Endog_Error(self.y, self.X, self.yd, self.q, self.w)
-        betas = np.array([[55.36095292], [0.46411479], [-0.66883535], [0.38989939]])
-        print("Running reduced-tolernace test in L181 of test_error_sp_sparse.py")
-        np.testing.assert_allclose(reg.betas, betas, RTOL + 0.0001)
-        u = np.array([26.55951566])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e = np.array([31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        predy = np.array([53.9074875])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
+        print('Running reduced-tolernace test in L181 of test_error_sp_sparse.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL + .0001)
+        u = np.array([ 26.55951566])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        e = np.array([ 31.23925425])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        predy = np.array([ 53.9074875])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_allclose(reg.x.toarray()[0], x, RTOL)
-        yend = np.array([15.72598])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.z.toarray()[0], z, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.   ,  19.531])
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
+        yend = np.array([  15.72598])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.z.toarray()[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                [529.15840986, -15.78336736, -8.38021053],
-                [-15.78336736, 0.54023504, 0.23112032],
-                [-8.38021053, 0.23112032, 0.14497738],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        vm = np.array([[ 529.15840986,  -15.78336736,   -8.38021053],
+       [ -15.78336736,    0.54023504,    0.23112032],
+       [  -8.38021053,    0.23112032,    0.14497738]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.346472557570858
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         sig2 = 192.5002
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
-        std_err = np.array([23.003401, 0.73500657, 0.38075777])
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                [2.40664208, 0.01609994],
-                [0.63144305, 0.52775088],
-                [-1.75659016, 0.07898769],
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-
-
-class TestBaseGMCombo(unittest.TestCase):
-    def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
-        y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
-        X = []
-        X.append(db.by_col("INC"))
-        X.append(db.by_col("CRIME"))
-        self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
-    def test_model(self):
-        # Only spatial lag
-        yd2, q2 = utils.set_endog(self.y, self.X, self.w, None, None, 1, True)
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
-        self.X = sparse.csr_matrix(self.X)
-        reg = SP.BaseGM_Combo(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse)
-        betas = np.array(
-            [[57.61123461], [0.73441314], [-0.59459416], [-0.21762921], [0.54732051]]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([25.57932637])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e_filtered = np.array([31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0], e_filtered, RTOL)
-        predy = np.array([54.88767663])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
-        n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
-        k = 4
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x.toarray()[0], x, RTOL)
-        yend = np.array([35.4585005])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        z = np.array([1.0, 19.531, 15.72598, 35.4585005])
-        np.testing.assert_allclose(reg.z.toarray()[0], z, RTOL)
-        my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
-        sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array([22.85691168, 0.48786563, 0.17914357, 0.46449287])
-        np.testing.assert_allclose(np.sqrt(reg.vm.diagonal()), vm, RTOL)
-        sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
+        std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 
 class TestGMCombo(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
     def test_model(self):
         # Only spatial lag
         reg = SP.GM_Combo(self.y, self.X, w=self.w)
-        e_reduced = np.array([28.18617481])
-        np.testing.assert_allclose(reg.e_pred[0], e_reduced, RTOL)
-        predy_e = np.array([52.28082782])
-        np.testing.assert_allclose(reg.predy_e[0], predy_e, RTOL)
-        betas = np.array(
-            [[57.61123515], [0.73441313], [-0.59459416], [-0.21762921], [0.54732051]]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([25.57932637])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e_filtered = np.array([31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0], e_filtered, RTOL)
-        predy = np.array([54.88767685])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        e_reduced = np.array([ 28.18617481])
+        np.testing.assert_allclose(reg.e_pred[0],e_reduced,RTOL)
+        predy_e = np.array([ 52.28082782])
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,RTOL)
+        betas = np.array([[ 57.61123515],[  0.73441313], [ -0.59459416], [ -0.21762921], [  0.54732051]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 25.57932637])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        e_filtered = np.array([ 31.65374945])
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
+        predy = np.array([ 54.88767685])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 4
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x.toarray()[0], x, RTOL)
-        yend = np.array([35.4585005])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        z = np.array([1.0, 19.531, 15.72598, 35.4585005])
-        np.testing.assert_allclose(reg.z.toarray()[0], z, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
+        yend = np.array([  35.4585005])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
+        np.testing.assert_allclose(reg.z.toarray()[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array([22.85691168, 0.48786563, 0.17914357, 0.46449287])
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
+        vm = np.array([22.85691168,  0.48786563,  0.17914357,  0.46449287])
         np.testing.assert_allclose(np.sqrt(reg.vm.diagonal()), vm, RTOL)
         sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2, sig2, RTOL)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3018280166937799
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.3561355587000738
-        np.testing.assert_allclose(reg.pr2_e, pr2_e, RTOL)
-        std_err = np.array([22.85692222, 0.48786559, 0.17914356, 0.46449318])
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                [2.52051597e00, 1.17182922e-02],
-                [1.50535954e00, 1.32231664e-01],
-                [-3.31909311e00, 9.03103123e-04],
-                [-4.68530506e-01, 6.39405261e-01],
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
+        std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
-
-if __name__ == "__main__":
-    start_suppress = np.get_printoptions()["suppress"]
-    np.set_printoptions(suppress=True)
+if __name__ == '__main__':
+    start_suppress = np.get_printoptions()['suppress']
+    np.set_printoptions(suppress=True) 
     unittest.main()
     np.set_printoptions(suppress=start_suppress)
+

--- a/spreg/tests/test_twosls_sp_regimes.py
+++ b/spreg/tests/test_twosls_sp_regimes.py
@@ -6,527 +6,349 @@ from spreg import utils
 from spreg.twosls_sp import GM_Lag
 from libpysal.common import RTOL
 
-
 class TestGMLag_Regimes(unittest.TestCase):
     def setUp(self):
-        self.w = libpysal.weights.Queen.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-        self.db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        self.w = libpysal.weights.Queen.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
+        self.db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), 'r')
         y = np.array(self.db.by_col("CRIME"))
-        self.y = np.reshape(y, (49, 1))
-        self.r_var = "NSA"
+        self.y = np.reshape(y, (49,1))
+        self.r_var = 'NSA'
         self.regimes = self.db.by_col(self.r_var)
 
     def test___init__(self):
-        # Matches SpaceStat
+        #Matches SpaceStat
         X = []
         X.append(self.db.by_col("INC"))
         X.append(self.db.by_col("HOVAL"))
         self.X = np.array(X).T
-        reg = GM_Lag_Regimes(
-            self.y,
-            self.X,
-            self.regimes,
-            w=self.w,
-            sig2n_k=True,
-            regime_lag_sep=False,
-            regime_err_sep=False,
-        )
-        betas = np.array(
-            [
-                [45.14892906],
-                [-1.42593383],
-                [-0.11501037],
-                [40.99023016],
-                [-0.81498302],
-                [-0.28391409],
-                [0.4736163],
-            ]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        e_5 = np.array(
-            [[-1.47960519], [-7.93748769], [-5.88561835], [-13.37941105], [5.2524303]]
-        )
-        np.testing.assert_allclose(reg.e_pred[0:5], e_5, RTOL)
-        h_0 = np.array(
-            [[0.0, 0.0, 0.0, 1.0, 19.531, 80.467003, 0.0, 0.0, 18.594, 35.4585005]]
-        )
-        np.testing.assert_allclose(reg.h[0] * np.eye(10), h_0)
+        reg = GM_Lag_Regimes(self.y, self.X, self.regimes, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False) 
+        betas = np.array([[ 45.14892906],
+       [ -1.42593383],
+       [ -0.11501037],
+       [ 40.99023016],
+       [ -0.81498302],
+       [ -0.28391409],
+       [  0.4736163 ]])
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
+        e_5 = np.array([[ -1.47960519],
+       [ -7.93748769],
+       [ -5.88561835],
+       [-13.37941105],
+       [  5.2524303 ]])
+        np.testing.assert_allclose(reg.e_pred[0:5], e_5,RTOL)
+        h_0 = np.array([[  0.       ,   0.       ,   0.       ,   1.       ,  19.531    ,
+         80.467003 ,   0.       ,   0.       ,  18.594    ,  35.4585005]])
+        np.testing.assert_allclose(reg.h[0]*np.eye(10), h_0)
         self.assertEqual(reg.k, 7)
         self.assertEqual(reg.kstar, 1)
-        np.testing.assert_allclose(reg.mean_y, 35.128823897959187, RTOL)
+        np.testing.assert_allclose(reg.mean_y, 35.128823897959187,RTOL)
         self.assertEqual(reg.n, 49)
-        np.testing.assert_allclose(reg.pr2, 0.6572182131915739, RTOL)
-        np.testing.assert_allclose(reg.pr2_e, 0.5779687278635434, RTOL)
-        pfora1a2 = np.array(
-            [
-                -2.15017629,
-                -0.30169328,
-                -0.07603704,
-                -22.06541809,
-                0.45738058,
-                0.02805828,
-                0.39073923,
-            ]
-        )
-        np.testing.assert_allclose(reg.pfora1a2[0], pfora1a2, RTOL)
-        predy_5 = np.array(
-            [[13.93216104], [23.46424269], [34.43510955], [44.32473878], [44.39117516]]
-        )
-        np.testing.assert_allclose(reg.predy[0:5], predy_5, RTOL)
-        predy_e_5 = np.array(
-            [[17.20558519], [26.73924169], [36.51239935], [45.76717105], [45.4790797]]
-        )
-        np.testing.assert_allclose(reg.predy_e[0:5], predy_e_5, RTOL)
-        q_5 = np.array([[0.0, 0.0, 18.594, 35.4585005]])
-        np.testing.assert_allclose(reg.q[0] * np.eye(4), q_5, RTOL)
-        self.assertEqual(reg.robust, "unadjusted")
-        np.testing.assert_allclose(reg.sig2n_k, 109.76462904625834, RTOL)
-        np.testing.assert_allclose(reg.sig2n, 94.08396775393571, RTOL)
-        np.testing.assert_allclose(reg.sig2, 109.76462904625834, RTOL)
-        np.testing.assert_allclose(reg.std_y, 16.732092091229699, RTOL)
-        u_5 = np.array(
-            [[1.79381896], [-4.66248869], [-3.80832855], [-11.93697878], [6.34033484]]
-        )
-        np.testing.assert_allclose(reg.u[0:5], u_5, RTOL)
-        np.testing.assert_allclose(reg.utu, 4610.11441994285, RTOL)
-        varb = np.array(
-            [
-                1.23841820e00,
-                -3.65620114e-02,
-                -1.21919663e-03,
-                1.00057547e00,
-                -2.07403182e-02,
-                -1.27232693e-03,
-                -1.77184084e-02,
-            ]
-        )
-        np.testing.assert_allclose(reg.varb[0], varb, RTOL)
-        vm = np.array(
-            [
-                1.35934514e02,
-                -4.01321561e00,
-                -1.33824666e-01,
-                1.09827796e02,
-                -2.27655334e00,
-                -1.39656494e-01,
-                -1.94485452e00,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        x_0 = np.array([[0.0, 0.0, 0.0, 1.0, 19.531, 80.467003]])
-        np.testing.assert_allclose(reg.x[0] * np.eye(6), x_0, RTOL)
-        y_5 = np.array([[15.72598], [18.801754], [30.626781], [32.38776], [50.73151]])
-        np.testing.assert_allclose(reg.y[0:5], y_5, RTOL)
-        yend_5 = np.array(
-            [[24.7142675], [26.24684033], [29.411751], [34.64647575], [40.4653275]]
-        )
-        np.testing.assert_allclose(reg.yend[0:5] * np.array([[1]]), yend_5, RTOL)
-        z_0 = np.array([[0.0, 0.0, 0.0, 1.0, 19.531, 80.467003, 24.7142675]])
-        np.testing.assert_allclose(reg.z[0] * np.eye(7), z_0, RTOL)
-        zthhthi = np.array(
-            [
-                1.00000000e00,
-                -2.35922393e-16,
-                5.55111512e-17,
-                0.00000000e00,
-                0.00000000e00,
-                0.00000000e00,
-                -4.44089210e-16,
-                2.22044605e-16,
-                0.00000000e00,
-                0.00000000e00,
-            ]
-        )
+        np.testing.assert_allclose(reg.pr2, 0.6572182131915739,RTOL)
+        np.testing.assert_allclose(reg.pr2_e, 0.5779687278635434,RTOL)
+        pfora1a2 = np.array([ -2.15017629,  -0.30169328,  -0.07603704, -22.06541809,
+         0.45738058,   0.02805828,   0.39073923]) 
+        np.testing.assert_allclose(reg.pfora1a2[0], pfora1a2,RTOL)
+        predy_5 = np.array([[ 13.93216104],
+       [ 23.46424269],
+       [ 34.43510955],
+       [ 44.32473878],
+       [ 44.39117516]])
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
+        predy_e_5 = np.array([[ 17.20558519],
+       [ 26.73924169],
+       [ 36.51239935],
+       [ 45.76717105],
+       [ 45.4790797 ]])
+        np.testing.assert_allclose(reg.predy_e[0:5], predy_e_5,RTOL)
+        q_5 = np.array([[  0.       ,   0.       ,  18.594    ,  35.4585005]])
+        np.testing.assert_allclose(reg.q[0]*np.eye(4), q_5, RTOL)
+        self.assertEqual(reg.robust, 'unadjusted')
+        np.testing.assert_allclose(reg.sig2n_k, 109.76462904625834,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 94.08396775393571,RTOL)
+        np.testing.assert_allclose(reg.sig2, 109.76462904625834,RTOL)
+        np.testing.assert_allclose(reg.std_y, 16.732092091229699,RTOL)
+        u_5 = np.array([[  1.79381896],
+       [ -4.66248869],
+       [ -3.80832855],
+       [-11.93697878],
+       [  6.34033484]])
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 4610.11441994285,RTOL)
+        varb = np.array([  1.23841820e+00,  -3.65620114e-02,  -1.21919663e-03,
+         1.00057547e+00,  -2.07403182e-02,  -1.27232693e-03,
+        -1.77184084e-02])
+        np.testing.assert_allclose(reg.varb[0], varb,RTOL)
+        vm = np.array([  1.35934514e+02,  -4.01321561e+00,  -1.33824666e-01,
+         1.09827796e+02,  -2.27655334e+00,  -1.39656494e-01,
+        -1.94485452e+00])
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
+        x_0 = np.array([[  0.      ,   0.      ,   0.      ,   1.      ,  19.531   ,
+         80.467003]])
+        np.testing.assert_allclose(reg.x[0]*np.eye(6), x_0,RTOL)
+        y_5 = np.array([[ 15.72598 ],
+       [ 18.801754],
+       [ 30.626781],
+       [ 32.38776 ],
+       [ 50.73151 ]])
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
+        yend_5 = np.array([[ 24.7142675 ],
+       [ 26.24684033],
+       [ 29.411751  ],
+       [ 34.64647575],
+       [ 40.4653275 ]])
+        np.testing.assert_allclose(reg.yend[0:5]*np.array([[1]]), yend_5,RTOL)
+        z_0 = np.array([[  0.       ,   0.       ,   0.       ,   1.       ,  19.531    ,
+         80.467003 ,  24.7142675]]) 
+        np.testing.assert_allclose(reg.z[0]*np.eye(7), z_0,RTOL)
+        zthhthi = np.array([  1.00000000e+00,  -2.35922393e-16,   5.55111512e-17,
+         0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
+        -4.44089210e-16,   2.22044605e-16,   0.00000000e+00,
+         0.00000000e+00])
         # np.testing.assert_allclose(reg.zthhthi[0], zthhthi, RTOL)
         np.testing.assert_array_almost_equal(reg.zthhthi[0], zthhthi)
-        chow_regi = np.array(
-            [[0.19692667, 0.65721307], [0.5666492, 0.45159351], [0.45282066, 0.5009985]]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_regi, RTOL)
-        np.testing.assert_allclose(reg.chow.joint[0], 0.82409867601863462, RTOL)
-
+        chow_regi = np.array([[ 0.19692667,  0.65721307],
+       [ 0.5666492 ,  0.45159351],
+       [ 0.45282066,  0.5009985 ]])
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.82409867601863462,RTOL)
+    
     def test_init_discbd(self):
-        # Matches SpaceStat.
+        #Matches SpaceStat.
         X = np.array(self.db.by_col("INC"))
-        X = np.reshape(X, (49, 1))
+        X = np.reshape(X, (49,1))
         yd = np.array(self.db.by_col("HOVAL"))
-        yd = np.reshape(yd, (49, 1))
+        yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
-        q = np.reshape(q, (49, 1))
-        reg = GM_Lag_Regimes(
-            self.y,
-            X,
-            self.regimes,
-            yend=yd,
-            q=q,
-            lag_q=False,
-            w=self.w,
-            sig2n_k=True,
-            regime_lag_sep=False,
-            regime_err_sep=False,
-        )
-        tbetas = np.array(
-            [
-                [42.7266306],
-                [-0.15552345],
-                [37.70545276],
-                [-0.5341577],
-                [-0.68305796],
-                [-0.37106077],
-                [0.55809516],
-            ]
-        )
-        np.testing.assert_allclose(tbetas, reg.betas, RTOL)
-        vm = np.array(
-            [
-                270.62979422,
-                3.62539081,
-                327.89638627,
-                6.24949355,
-                -5.25333106,
-                -6.01743515,
-                -4.19290074,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        e_3 = np.array([[-0.33142796], [-9.51719607], [-7.86272153]])
-        np.testing.assert_allclose(reg.e_pred[0:3], e_3, RTOL)
-        u_3 = np.array([[4.51839601], [-5.67363147], [-5.1927562]])
-        np.testing.assert_allclose(reg.u[0:3], u_3, RTOL)
-        predy_3 = np.array([[11.20758399], [24.47538547], [35.8195372]])
-        np.testing.assert_allclose(reg.predy[0:3], predy_3, RTOL)
-        predy_e_3 = np.array([[16.05740796], [28.31895007], [38.48950253]])
-        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3, RTOL)
-        chow_regi = np.array(
-            [
-                [0.13130991, 0.71707772],
-                [0.04740966, 0.82763357],
-                [0.15474413, 0.6940423],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_regi, RTOL)
-        np.testing.assert_allclose(reg.chow.joint[0], 0.31248100032096549, RTOL)
-
+        q = np.reshape(q, (49,1))
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, lag_q=False, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False) 
+        tbetas = np.array([[ 42.7266306 ],
+       [ -0.15552345],
+       [ 37.70545276],
+       [ -0.5341577 ],
+       [ -0.68305796],
+       [ -0.37106077],
+       [  0.55809516]])
+        np.testing.assert_allclose(tbetas, reg.betas,RTOL)
+        vm = np.array([ 270.62979422,    3.62539081,  327.89638627,    6.24949355,
+         -5.25333106,   -6.01743515,   -4.19290074])
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
+        e_3 = np.array([[-0.33142796],
+       [-9.51719607],
+       [-7.86272153]])
+        np.testing.assert_allclose(reg.e_pred[0:3], e_3,RTOL)
+        u_3 = np.array([[ 4.51839601],
+       [-5.67363147],
+       [-5.1927562 ]])
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
+        predy_3 = np.array([[ 11.20758399],
+       [ 24.47538547],
+       [ 35.8195372 ]])
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
+        predy_e_3 = np.array([[ 16.05740796],
+       [ 28.31895007],
+       [ 38.48950253]])
+        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3,RTOL)
+        chow_regi = np.array([[ 0.13130991,  0.71707772],
+       [ 0.04740966,  0.82763357],
+       [ 0.15474413,  0.6940423 ]])
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.31248100032096549,RTOL)
+    
     def test_lag_q(self):
         X = np.array(self.db.by_col("INC"))
-        X = np.reshape(X, (49, 1))
+        X = np.reshape(X, (49,1))
         yd = np.array(self.db.by_col("HOVAL"))
-        yd = np.reshape(yd, (49, 1))
+        yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
-        q = np.reshape(q, (49, 1))
-        reg = GM_Lag_Regimes(
-            self.y,
-            X,
-            self.regimes,
-            yend=yd,
-            q=q,
-            w=self.w,
-            sig2n_k=True,
-            regime_lag_sep=False,
-            regime_err_sep=False,
-        )
-        tbetas = np.array(
-            [
-                [37.87698329],
-                [-0.89426982],
-                [31.4714777],
-                [-0.71640525],
-                [-0.28494432],
-                [-0.2294271],
-                [0.62996544],
-            ]
-        )
-        np.testing.assert_allclose(tbetas, reg.betas, RTOL)
-        vm = np.array(
-            [
-                128.25714554,
-                -0.38975354,
-                95.7271044,
-                -1.8429218,
-                -1.75331978,
-                -0.18240338,
-                -1.67767464,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        chow_regi = np.array(
-            [
-                [0.43494049, 0.50957463],
-                [0.02089281, 0.88507135],
-                [0.01180501, 0.91347943],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_regi, RTOL)
-        np.testing.assert_allclose(reg.chow.joint[0], 0.54288190938307757, RTOL)
-
+        q = np.reshape(q, (49,1))
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False) 
+        tbetas = np.array([[ 37.87698329],
+       [ -0.89426982],
+       [ 31.4714777 ],
+       [ -0.71640525],
+       [ -0.28494432],
+       [ -0.2294271 ],
+       [  0.62996544]])
+        np.testing.assert_allclose(tbetas, reg.betas,RTOL)
+        vm = np.array([ 128.25714554,   -0.38975354,   95.7271044 ,   -1.8429218 ,
+         -1.75331978,   -0.18240338,   -1.67767464])
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
+        chow_regi = np.array([[ 0.43494049,  0.50957463],
+       [ 0.02089281,  0.88507135],
+       [ 0.01180501,  0.91347943]])
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.54288190938307757,RTOL)
+    
     def test_all_regi(self):
         X = np.array(self.db.by_col("INC"))
-        X = np.reshape(X, (49, 1))
+        X = np.reshape(X, (49,1))
         yd = np.array(self.db.by_col("HOVAL"))
-        yd = np.reshape(yd, (49, 1))
+        yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
-        q = np.reshape(q, (49, 1))
-        reg = GM_Lag_Regimes(
-            self.y,
-            X,
-            self.regimes,
-            yend=yd,
-            q=q,
-            w=self.w,
-            regime_lag_sep=False,
-            regime_err_sep=True,
-        )
-        tbetas = np.array(
-            [
-                [
-                    37.87698329,
-                    -0.89426982,
-                    31.4714777,
-                    -0.71640525,
-                    -0.28494432,
-                    -0.2294271,
-                    0.62996544,
-                ]
-            ]
-        )
-        np.testing.assert_allclose(tbetas, reg.betas.T, RTOL)
-        vm = np.array(
-            [
-                70.38291551,
-                -0.64868787,
-                49.25453215,
-                -0.62851534,
-                -0.75413453,
-                -0.12674433,
-                -0.97179236,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        e_3 = np.array([[-2.66997799], [-7.69786264], [-4.39412782]])
-        np.testing.assert_allclose(reg.e_pred[0:3], e_3, RTOL)
-        u_3 = np.array([[1.13879007], [-3.76873198], [-1.89671717]])
-        np.testing.assert_allclose(reg.u[0:3], u_3, RTOL)
-        predy_3 = np.array([[14.58718993], [22.57048598], [32.52349817]])
-        np.testing.assert_allclose(reg.predy[0:3], predy_3, RTOL)
-        predy_e_3 = np.array([[18.39595799], [26.49961664], [35.02090882]])
-        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3, RTOL)
-        chow_regi = np.array(
-            [
-                [0.60091096, 0.43823066],
-                [0.03006744, 0.8623373],
-                [0.01943727, 0.88912016],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_regi, RTOL)
-        np.testing.assert_allclose(reg.chow.joint[0], 0.88634854058300516, RTOL)
-
+        q = np.reshape(q, (49,1))
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, regime_lag_sep=False, regime_err_sep=False) 
+        tbetas = np.array([[ 37.87698329,  -0.89426982,  31.4714777 ,  -0.71640525,
+         -0.28494432,  -0.2294271 ,   0.62996544]])
+        np.testing.assert_allclose(tbetas, reg.betas.T,RTOL)
+        vm = np.array([109.934696,  -0.334074,  82.051804,  -1.579647,  -1.502846,
+        -0.156346,  -1.438007])
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
+        e_3 = np.array([[-2.66997799],
+       [-7.69786264],
+       [-4.39412782]])
+        np.testing.assert_allclose(reg.e_pred[0:3], e_3,RTOL)
+        u_3 = np.array([[ 1.13879007],
+       [-3.76873198],
+       [-1.89671717]])
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
+        predy_3 = np.array([[ 14.58718993],
+       [ 22.57048598],
+       [ 32.52349817]])
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
+        predy_e_3 = np.array([[ 18.39595799],
+       [ 26.49961664],
+       [ 35.02090882]])
+        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3,RTOL)
+        chow_regi = np.array([[0.507431, 0.476253],
+       [0.024375, 0.875935],
+       [0.013773, 0.906578]])
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,1e-04)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.633362,RTOL)
+    
     def test_all_regi_sig2(self):
-        # Artficial:
+        #Artficial:
         n = 256
-        x1 = np.random.uniform(-10, 10, (n, 1))
-        x2 = np.random.uniform(1, 5, (n, 1))
-        q = x2 + np.random.normal(0, 1, (n, 1))
-        x = np.hstack((x1, x2))
-        y = np.dot(
-            np.hstack((np.ones((n, 1)), x)), np.array([[1], [0.5], [2]])
-        ) + np.random.normal(0, 1, (n, 1))
+        x1 = np.random.uniform(-10,10,(n,1))
+        x2 = np.random.uniform(1,5,(n,1))
+        q = x2 + np.random.normal(0,1,(n,1))
+        x = np.hstack((x1,x2))
+        y = np.dot(np.hstack((np.ones((n,1)),x)),np.array([[1],[0.5],[2]])) + np.random.normal(0,1,(n,1))
         latt = int(np.sqrt(n))
-        w = libpysal.weights.util.lat2W(latt, latt)
-        w.transform = "r"
-        regi = [0] * (n // 2) + [1] * (n // 2)
-        model = GM_Lag_Regimes(
-            y, x1, regi, q=q, yend=x2, w=w, regime_lag_sep=True, regime_err_sep=True
-        )
-        w1 = libpysal.weights.util.lat2W(latt // 2, latt)
-        w1.transform = "r"
-        model1 = GM_Lag(
-            y[0 : (n // 2)].reshape((n // 2), 1),
-            x1[0 : (n // 2)],
-            yend=x2[0 : (n // 2)],
-            q=q[0 : (n // 2)],
-            w=w1,
-        )
-        model2 = GM_Lag(
-            y[(n // 2) : n].reshape((n // 2), 1),
-            x1[(n // 2) : n],
-            yend=x2[(n // 2) : n],
-            q=q[(n // 2) : n],
-            w=w1,
-        )
+        w = libpysal.weights.util.lat2W(latt,latt)
+        w.transform='r'
+        regi = [0]*(n//2) + [1]*(n//2)
+        model = GM_Lag_Regimes(y, x1, regi, q=q, yend=x2, w=w, regime_lag_sep=True, regime_err_sep=True)
+        w1 = libpysal.weights.util.lat2W(latt//2,latt)
+        w1.transform='r'
+        model1 = GM_Lag(y[0:(n//2)].reshape((n//2),1), x1[0:(n//2)],yend=x2[0:(n//2)], q=q[0:(n//2)], w=w1)
+        model2 = GM_Lag(y[(n//2):n].reshape((n//2),1), x1[(n//2):n],yend=x2[(n//2):n], q=q[(n//2):n], w=w1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_allclose(model.betas, tbetas)
-        vm = np.hstack((model1.vm.diagonal(), model2.vm.diagonal()))
-        np.testing.assert_allclose(model.vm.diagonal(), vm, RTOL)
-        # Columbus:
+        np.testing.assert_allclose(model.betas,tbetas)
+        vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
+        np.testing.assert_allclose(model.vm.diagonal(), vm,RTOL)
+        #Columbus:
         X = np.array(self.db.by_col("INC"))
-        X = np.reshape(X, (49, 1))
+        X = np.reshape(X, (49,1))
         yd = np.array(self.db.by_col("HOVAL"))
-        yd = np.reshape(yd, (49, 1))
+        yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
-        q = np.reshape(q, (49, 1))
-        reg = GM_Lag_Regimes(
-            self.y,
-            X,
-            self.regimes,
-            yend=yd,
-            q=q,
-            w=self.w,
-            regime_lag_sep=True,
-            regime_err_sep=True,
-        )
-        tbetas = np.array(
-            [
-                [42.35827477],
-                [-0.09472413],
-                [-0.68794223],
-                [0.54482537],
-                [32.24228762],
-                [-0.12304063],
-                [-0.46840307],
-                [0.67108156],
-            ]
-        )
+        q = np.reshape(q, (49,1))
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w,regime_lag_sep=True, regime_err_sep = True) 
+        tbetas = np.array([[ 42.35827477],
+       [ -0.09472413],
+       [ -0.68794223],
+       [  0.54482537],
+       [ 32.24228762],
+       [ -0.12304063],
+       [ -0.46840307],
+       [  0.67108156]])
         np.testing.assert_allclose(tbetas, reg.betas)
-        vm = np.array(
-            [200.92894859, 4.56244927, -4.85603079, -2.9755413, 0.0, 0.0, 0.0, 0.0]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        e_3 = np.array([[-1.32209547], [-13.15611199], [-11.62357696]])
-        np.testing.assert_allclose(reg.e_pred[0:3], e_3, RTOL)
-        u_3 = np.array([[6.99250069], [-7.5665856], [-7.04753328]])
-        np.testing.assert_allclose(reg.u[0:3], u_3, RTOL)
-        predy_3 = np.array([[8.73347931], [26.3683396], [37.67431428]])
-        np.testing.assert_allclose(reg.predy[0:3], predy_3, RTOL)
-        predy_e_3 = np.array([[17.04807547], [31.95786599], [42.25035796]])
-        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3, RTOL)
-        chow_regi = np.array(
-            [
-                [1.51825373e-01, 6.96797034e-01],
-                [3.20105698e-04, 9.85725412e-01],
-                [8.58836996e-02, 7.69476896e-01],
-                [1.01357290e-01, 7.50206873e-01],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_regi, RTOL)
-        np.testing.assert_allclose(reg.chow.joint[0], 0.38417230022512161, RTOL)
+        vm = np.array([ 200.92894859,    4.56244927,   -4.85603079,   -2.9755413 ,
+          0.        ,    0.        ,    0.        ,    0.        ])
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
+        e_3 = np.array([[ -1.32209547],
+       [-13.15611199],
+       [-11.62357696]])
+        np.testing.assert_allclose(reg.e_pred[0:3], e_3,RTOL)
+        u_3 = np.array([[ 6.99250069],
+       [-7.5665856 ],
+       [-7.04753328]])
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
+        predy_3 = np.array([[  8.73347931],
+       [ 26.3683396 ],
+       [ 37.67431428]])
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
+        predy_e_3 = np.array([[ 17.04807547],
+       [ 31.95786599],
+       [ 42.25035796]])
+        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3,RTOL)
+        chow_regi = np.array([[  1.51825373e-01,   6.96797034e-01],
+       [  3.20105698e-04,   9.85725412e-01],
+       [  8.58836996e-02,   7.69476896e-01],
+       [  1.01357290e-01,   7.50206873e-01]])
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.38417230022512161,RTOL)
 
     def test_fixed_const(self):
         X = np.array(self.db.by_col("INC"))
-        X = np.reshape(X, (49, 1))
+        X = np.reshape(X, (49,1))
         yd = np.array(self.db.by_col("HOVAL"))
-        yd = np.reshape(yd, (49, 1))
+        yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
-        q = np.reshape(q, (49, 1))
-        reg = GM_Lag_Regimes(
-            self.y,
-            X,
-            self.regimes,
-            yend=yd,
-            q=q,
-            w=self.w,
-            constant_regi="one",
-            regime_lag_sep=False,
-            regime_err_sep=False,
-        )
-        tbetas = np.array(
-            [
-                [-0.37658823],
-                [-0.9666079],
-                [35.5445944],
-                [-0.45793559],
-                [-0.24216904],
-                [0.62500602],
-            ]
-        )
-        np.testing.assert_allclose(tbetas, reg.betas, RTOL)
-        vm = np.array(
-            [1.4183697, -0.05975784, -0.27161863, -0.62517245, 0.02266177, 0.00312976]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        e_3 = np.array([[0.17317815], [-5.53766328], [-3.82889307]])
-        np.testing.assert_allclose(reg.e_pred[0:3], e_3, RTOL)
-        u_3 = np.array([[3.10025518], [-1.83150689], [-1.49598494]])
-        np.testing.assert_allclose(reg.u[0:3], u_3, RTOL)
-        predy_3 = np.array([[12.62572482], [20.63326089], [32.12276594]])
-        np.testing.assert_allclose(reg.predy[0:3], predy_3, RTOL)
-        predy_e_3 = np.array([[15.55280185], [24.33941728], [34.45567407]])
-        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3, RTOL)
-        chow_regi = np.array(
-            [[1.85767047e-01, 6.66463269e-01], [1.19445012e01, 5.48089036e-04]]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_regi, RTOL)
-        np.testing.assert_allclose(reg.chow.joint[0], 12.017256217621382, RTOL)
+        q = np.reshape(q, (49,1))
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, constant_regi='one', regime_lag_sep=False, regime_err_sep=False) 
+        tbetas = np.array([[ -0.37658823],
+       [ -0.9666079 ],
+       [ 35.5445944 ],
+       [ -0.45793559],
+       [ -0.24216904],
+       [  0.62500602]])
+        np.testing.assert_allclose(tbetas, reg.betas,RTOL)
+        vm = np.array([ 1.4183697 , -0.05975784, -0.27161863, -0.62517245,  0.02266177,
+        0.00312976])
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
+        e_3 = np.array([[ 0.17317815],
+       [-5.53766328],
+       [-3.82889307]])
+        np.testing.assert_allclose(reg.e_pred[0:3], e_3,RTOL)
+        u_3 = np.array([[ 3.10025518],
+       [-1.83150689],
+       [-1.49598494]])
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
+        predy_3 = np.array([[ 12.62572482],
+       [ 20.63326089],
+       [ 32.12276594]])
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
+        predy_e_3 = np.array([[ 15.55280185],
+       [ 24.33941728],
+       [ 34.45567407]])
+        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3,RTOL)
+        chow_regi = np.array([[  1.85767047e-01,   6.66463269e-01],
+       [  1.19445012e+01,   5.48089036e-04]])
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 12.017256217621382,RTOL)
 
     def test_names(self):
-        y_var = "CRIME"
-        x_var = ["INC"]
+        y_var = 'CRIME'
+        x_var = ['INC']
         x = np.array([self.db.by_col(name) for name in x_var]).T
-        yd_var = ["HOVAL"]
+        yd_var = ['HOVAL']
         yd = np.array([self.db.by_col(name) for name in yd_var]).T
-        q_var = ["DISCBD"]
+        q_var = ['DISCBD']
         q = np.array([self.db.by_col(name) for name in q_var]).T
-        r_var = "NSA"
-        reg = GM_Lag_Regimes(
-            self.y,
-            x,
-            self.regimes,
-            yend=yd,
-            q=q,
-            w=self.w,
-            name_y=y_var,
-            name_x=x_var,
-            name_yend=yd_var,
-            name_q=q_var,
-            name_regimes=r_var,
-            name_ds="columbus",
-            name_w="columbus.gal",
-            regime_lag_sep=False,
-            regime_err_sep=False,
-        )
-        betas = np.array(
-            [
-                [37.87698329],
-                [-0.89426982],
-                [31.4714777],
-                [-0.71640525],
-                [-0.28494432],
-                [-0.2294271],
-                [0.62996544],
-            ]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        vm = np.array(
-            [
-                109.93469618,
-                -0.33407447,
-                82.05180377,
-                -1.57964725,
-                -1.50284553,
-                -0.15634575,
-                -1.43800683,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        chow_regi = np.array(
-            [
-                [0.50743058, 0.47625326],
-                [0.02437494, 0.87593468],
-                [0.01377251, 0.9065777],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_regi, RTOL)
-        np.testing.assert_allclose(reg.chow.joint[0], 0.63336222761359162, RTOL)
-        self.assertListEqual(reg.name_x, ["0_CONSTANT", "0_INC", "1_CONSTANT", "1_INC"])
-        self.assertListEqual(reg.name_yend, ["0_HOVAL", "1_HOVAL", "_Global_W_CRIME"])
-        self.assertListEqual(
-            reg.name_q,
-            ["0_DISCBD", "0_W_INC", "0_W_DISCBD", "1_DISCBD", "1_W_INC", "1_W_DISCBD"],
-        )
+        r_var = 'NSA'
+        reg = GM_Lag_Regimes(self.y, x, self.regimes, yend=yd, q=q, w=self.w, name_y=y_var, name_x=x_var, name_yend=yd_var, name_q=q_var, name_regimes=r_var, name_ds='columbus', name_w='columbus.gal', regime_lag_sep=False, regime_err_sep=False)
+        betas = np.array([[ 37.87698329],
+       [ -0.89426982],
+       [ 31.4714777 ],
+       [ -0.71640525],
+       [ -0.28494432],
+       [ -0.2294271 ],
+       [  0.62996544]])
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
+        vm = np.array([ 109.93469618,   -0.33407447,   82.05180377,   -1.57964725,
+         -1.50284553,   -0.15634575,   -1.43800683])
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
+        chow_regi = np.array([[ 0.50743058,  0.47625326],
+       [ 0.02437494,  0.87593468],
+       [ 0.01377251,  0.9065777 ]])
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.63336222761359162,RTOL)
+        self.assertListEqual(reg.name_x, ['0_CONSTANT', '0_INC', '1_CONSTANT', '1_INC'])
+        self.assertListEqual(reg.name_yend, ['0_HOVAL', '1_HOVAL', '_Global_W_CRIME'])
+        self.assertListEqual(reg.name_q, ['0_DISCBD', '0_W_INC', '0_W_DISCBD', '1_DISCBD', '1_W_INC', '1_W_DISCBD'])
         self.assertEqual(reg.name_y, y_var)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/spreg/user_output.py
+++ b/spreg/user_output.py
@@ -1,7 +1,8 @@
 """Internal helper files for user output."""
 
 __author__ = (
-    "Luc Anselin luc.anselin@asu.edu, "
+    "Luc Anselin lanselin@gmail.com, "
+    "Pedro Amaral pedrovma@gmail.com"
     "David C. Folch david.folch@asu.edu, "
     "Levi John Wolf levi.john.wolf@gmail.com, "
     "Jing Yao jingyao@asu.edu"
@@ -147,6 +148,23 @@ def set_name_yend_sp(name_y):
     """
     return "W_" + name_y
 
+def set_name_spatial_lags(names, w_lags):
+    """Set the spatial lag names for multiple variables and lag orders"
+
+    Parameters
+    ----------
+    names      : string
+                 Original variables' names.
+
+    Returns
+    -------
+    lag_names : string
+
+    """
+    lag_names = ["W_" + s for s in names]
+    for i in range(w_lags-1):
+        lag_names += ["W" + str(i+2) + "_" + s for s in names]
+    return lag_names
 
 def set_name_q_sp(name_x, w_lags, name_q, lag_q, force_all=False):
     """Set the spatial instrument names in regression; return generic name if user
@@ -544,8 +562,9 @@ def check_robust(robust, wk):
                     # NOTE: we are not checking for the case of exactly 1.0 ###
                     raise Exception("Off-diagonal entries must be less than 1.")
         elif robust.lower() == "white" or robust.lower() == "ogmm":
-            if wk:
-                raise Exception("White requires that wk be set to None")
+  #          if wk:
+  #              raise Exception("White requires that wk be set to None")
+            pass      # these options are not affected by wk
         else:
             raise Exception(
                 "invalid value passed to robust, see docs for valid options"


### PR DESCRIPTION
This PR incorporates several new developments into spreg.

Main changes:
- Refactoring of the output. The way the results from the models are printed to the users has been completely refactored. The new function is simpler and generic. It is based on pandas to create an 'output' attribute to the regression object that contains the most important information on the estimates from the model.
- Addition of slx_lags to all cross-section models. An argument slx_lags was added to all cross-section models to allow for the direct estimation of SLX models, Spatial Durbin Models (SDM) or GNS models.
- Creation of wrapper functions for the error models. Both error_sp and error_sp_regimes now have wrapper functions, 'GMM_Error' and 'GMM_Error_Regimes' that allow for easy estimation of error models based on the original Kelejian&Prucha1998 (kp98), homoskedastic (hom) or heteroskedastic (het, the default) estimators. The wrapper functions also allow specifications with extra endogenous variables or a spatial lag of the dependent variable.
- Several minor updates of fixes were also developed in this commit.

Despite the major changes, this commit does not break any previous code. This update was developed in a private branch by Luc Anselin and Pedro Amaral.