### PR TITLE
Update pyproject.toml – numpy version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
 "scipy>=0.11",
-"numpy>=1.3",
+"numpy>=1.23",
 "pandas",
 "libpysal>=4.0.0",
 "scikit-learn>=0.22",


### PR DESCRIPTION
There is no `numpy>=1.3`. This was probably introduced by typo at some point in the past.