### PR TITLE
Version 1.5

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -128,3 +128,27 @@ Diagnostic tests are useful for identifying model fit, sufficiency, and specific
     spreg.panel_rLMlag
     spreg.panel_rLMerror
     spreg.panel_Hausman
+
+DGP
+-----------
+
+Tools for simulating synthetic data according to data-generating processes implied by different spatial model specifications
+
+.. autosummary:: 
+    :toctree: generated/
+
+    spreg.dgp.make_error
+    spreg.dgp.make_x
+    spreg.dgp.make_wx
+    spreg.dgp.make_xb
+    spreg.dgp.make_wxg
+    spreg.dgp.dgp_errproc
+    spreg.dgp.dgp_ols
+    spreg.dgp.dgp_slx
+    spreg.dgp.dgp_sperror
+    spreg.dgp.dgp_slxerror
+    spreg.dgp.dgp_lag
+    spreg.dgp.dgp_spdurbin
+    spreg.dgp.dgp_lagerr
+    spreg.dgp.dgp_gns
+    spreg.dgp.dgp_mes

--- a/spreg/__init__.py
+++ b/spreg/__init__.py
@@ -2,6 +2,7 @@
 import contextlib
 from importlib.metadata import PackageNotFoundError, version
 
+from .dgp import *
 from .diagnostics import *
 from .diagnostics_panel import *
 from .diagnostics_sp import *

--- a/spreg/dgp.py
+++ b/spreg/dgp.py
@@ -11,8 +11,9 @@ import numpy as np
 import math
 import libpysal
 from scipy.linalg import expm
-import spreg
-    
+from .utils import inverse_prod
+
+
 __all__ = [
     "make_error",
     "make_x",
@@ -327,7 +328,7 @@ def dgp_errproc(u,w,lam=0.5,model='sar',imethod='power_exp'):
         print("Error: incompatible weights dimensions")
         return None
     if model == 'sar':
-        y = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+        y = inverse_prod(w,u,lam,inv_method=imethod)
     elif model == 'ma':
         y = u + lam * libpysal.weights.lag_spatial(w,u)
     else:
@@ -468,7 +469,7 @@ def dgp_sperror(u,xb,w,lam=0.5,model='sar',imethod='power_exp'):
         print("Error: incompatible weights dimensions")
         return None
     if model == 'sar':
-        u1 = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+        u1 = inverse_prod(w,u,lam,inv_method=imethod)
     elif model == 'ma':
         u1 = u + lam * libpysal.weights.lag_spatial(w,u)
     else:
@@ -532,7 +533,7 @@ def dgp_slxerror(u,xb,wxg,w,lam=0.5,model='sar',imethod='power_exp'):
         print("Error: incompatible weights dimensions")
         return None
     if model == 'sar':
-        u1 = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+        u1 = inverse_prod(w,u,lam,inv_method=imethod)
     elif model == 'ma':
         u1 = u + lam * libpysal.weights.lag_spatial(w,u)
     else:
@@ -587,7 +588,7 @@ def dgp_lag(u,xb,w,rho=0.5,imethod='power_exp'):
         print("Error: incompatible weights dimensions")
         return None
     y1 = xb + u
-    y = spreg.utils.inverse_prod(w,y1,rho,inv_method=imethod)
+    y = inverse_prod(w,y1,rho,inv_method=imethod)
     return y
     
 def dgp_spdurbin(u,xb,wxg,w,rho=0.5,imethod='power_exp'):
@@ -642,7 +643,7 @@ def dgp_spdurbin(u,xb,wxg,w,rho=0.5,imethod='power_exp'):
     if w.n != n1:
         print("Error: incompatible weights dimensions")
     y1 = xb + wxg + u
-    y = spreg.utils.inverse_prod(w,y1,rho,inv_method=imethod)
+    y = inverse_prod(w,y1,rho,inv_method=imethod)
     return y
     
 def dgp_lagerr(u,xb,w,rho=0.5,lam=0.2,model='sar',imethod='power_exp'):
@@ -695,14 +696,14 @@ def dgp_lagerr(u,xb,w,rho=0.5,lam=0.2,model='sar',imethod='power_exp'):
         print("Error: incompatible weights dimensions")
         return None
     if model == 'sar':
-        u1 = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+        u1 = inverse_prod(w,u,lam,inv_method=imethod)
     elif model == 'ma':
         u1 = u + lam * libpysal.weights.lag_spatial(w,u)
     else:
         print("Error: unsupported model type")
         return None
     y1 = xb + u1
-    y = spreg.utils.inverse_prod(w,y1,rho,inv_method=imethod)
+    y = inverse_prod(w,y1,rho,inv_method=imethod)
     return y
     
 def dgp_gns(u,xb,wxg,w,rho=0.5,lam=0.2,model='sar',imethod='power_exp'):
@@ -761,14 +762,14 @@ def dgp_gns(u,xb,wxg,w,rho=0.5,lam=0.2,model='sar',imethod='power_exp'):
     if w.n != n1:
         print("Error: incompatible weights dimensions")
     if model == 'sar':
-        u1 = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+        u1 = inverse_prod(w,u,lam,inv_method=imethod)
     elif model == 'ma':
         u1 = u + lam * libpysal.weights.lag_spatial(w,u)
     else:
         print("Error: unsupported model type")
         return None
     y1 = xb + wxg + u1
-    y = spreg.utils.inverse_prod(w,y1,rho,inv_method=imethod)
+    y = inverse_prod(w,y1,rho,inv_method=imethod)
     return y
     
 def dgp_mess(u,xb,w,rho=0.5):

--- a/spreg/dgp.py
+++ b/spreg/dgp.py
@@ -1,0 +1,835 @@
+"""
+Generating spatial models for specific DGP
+
+"""
+
+__author__ = "Luc Anselin lanselin@gmail.com,\
+     Pedro Amaral pedrovma@gmail.com,\
+     Renan Serenini renan.serenini@uniroma1.it"
+
+import numpy as np
+import math
+import libpysal
+from scipy.linalg import expm
+import spreg
+    
+__all__ = [
+    "make_error",
+    "make_x",
+    "make_wx",
+    "make_xb",
+    "make_wxg",
+    "dgp_errproc",
+    "dgp_ols",
+    "dgp_slx",
+    "dgp_sperror",
+    "dgp_slxerror",
+    "dgp_lag",
+    "dgp_spdurbin",
+    "dgp_lagerr",
+    "dgp_gns",
+    "dgp_mess"
+]
+    
+    
+def make_error(rng,n,mu=0,varu=1,method='normal'):
+    """
+    make_error: generate error term for a given distribution
+    
+    Arguments:
+    ----------
+    rng:      random number object
+    n:        number of observations
+    mu:       mean (when needed)
+    varu:     variance (when needed)
+    method:   type of distribution, one of
+              normal, laplace, cauchy, lognormal
+    
+    Returns:
+    --------
+    u:        nx1 vector of random errors
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> from spreg import make_error
+    >>> rng = np.random.default_rng(12345)
+    >>> make_error(rng,5)
+    array([[-1.42382504],
+           [ 1.26372846],
+           [-0.87066174],
+           [-0.25917323],
+           [-0.07534331]])
+
+    """
+    # normal - standard normal is default
+    if method == 'normal':
+        sdu = math.sqrt(varu)
+        u = rng.normal(loc=mu,scale=sdu,size=n).reshape(n,1)
+    # laplace with thicker tails
+    elif method == 'laplace':
+        sdu = math.sqrt(varu/2.0)
+        u = rng.laplace(loc=mu,scale=sdu,size=n).reshape(n,1)
+    # cauchy, ill-behaved, no mean or variance defined
+    elif method == 'cauchy':
+        u = rng.standard_cauchy(size=n).reshape(n,1)
+    elif method == 'lognormal':
+        sdu = math.sqrt(varu)
+        u = rng.lognormal(mean=mu,sigma=sdu,size=n).reshape(n,1)
+    # all other yield warning
+    else:
+        print('Warning: Unsupported distribution')
+        u = None
+    return u
+
+def make_x(rng,n,mu=[0],varu=[1],cor=0,method='uniform'):
+    """
+    make_x: generate a matrix of k columns of x for a given distribution  
+    
+    Arguments:
+    ----------
+    rng:      random number object
+    n:        number of observations
+    mu:       mean as a list
+    varu:     variance as a list
+    cor:      correlation as a float (for bivariate normal only)
+    method:   type of distribution, one of
+              uniform, normal, bivnormal (bivariate normal)
+    
+    Returns:
+    --------
+    x:        nxk matrix of x variables
+    
+    Note:
+    -----
+    Uniform and normal generate separate draws, bivariate normal generates
+    correlated draws
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> from spreg import make_x
+    >>> rng = np.random.default_rng(12345)
+    >>> make_x(rng,5,mu=[0,1],varu=[1,4])
+    array([[0.78751508, 2.30580253],
+           [1.09728308, 4.14520464],
+           [2.76215497, 1.29373239],
+           [2.3426149 , 4.6609906 ],
+           [1.35484323, 6.52500165]])
+
+    """
+    # check on k dimension
+    k = len(mu)
+    if k == len(varu):
+        # initialize
+        x = np.zeros((n,k))
+        for i in range(k):
+            # uniform - range is derived from variance since var = (1/12)range^2
+            # range is found as square root of 12 times variance
+            # for 0-1, varu should be 0.0833333
+            # low is always 0
+            if method == 'uniform':
+                sdu = math.sqrt(12.0*varu[i])
+                x[:,i] = rng.uniform(low=0,high=sdu,size=n)
+            # normal - independent normal draws
+            elif method == 'normal':
+                sdu = math.sqrt(varu[i])
+                x[:,i] = rng.normal(loc=mu[i],scale=sdu,size=n)
+            # bivariate normal - only for k=2
+            elif method == 'bivnormal':
+                if k != 2:
+                    print('Error: Wrong dimension for k')
+                    x = None
+                    return x
+                else:
+                    ucov = cor* math.sqrt(varu[0]*varu[1])
+                    mcov = [[varu[0],ucov],[ucov,varu[1]]]
+                    x = rng.multivariate_normal(mean=mu,cov=mcov,size=n)
+                    return x
+            else:
+                print('Warning: Unsupported distribution')
+                x = None
+    else:
+        x = None
+    return x
+
+def make_wx(x,w,o=1):
+    """
+    make_wx: generate a matrix spatially lagged x given matrix x  
+    
+             x must be previously generated using make_x, no constant included
+    
+    Arguments:
+    ----------
+    x:        x matrix - no constant
+    w:        row-standardized spatial weights in spreg format
+    o:        order of contiguity, default o=1
+    
+    Returns:
+    --------
+    wx:       nx(kxo) matrix of spatially lagged x variables
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_wx
+    >>> rng = np.random.default_rng(12345)
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> make_wx(x,w)[0:5,:]
+    array([[1.12509217],
+           [1.87409079],
+           [1.36225472],
+           [2.1491645 ],
+           [2.80255786]])
+
+    """
+    if w.n != x.shape[0]:
+        print("Error: incompatible weights dimensions")
+        return None
+    w1x = libpysal.weights.lag_spatial(w,x)
+    wx = w1x
+    if o > 1:
+        for i in range(1,o):
+            whx = libpysal.weights.lag_spatial(w,w1x)
+            w1x = whx
+            wx = np.hstack((wx,whx))
+    return wx
+        
+
+def make_xb(x,beta):
+    """
+    make_xb: generate a column xb as matrix x (constant added)  
+             times list beta (includes coefficient for constant term)
+    
+    Arguments:
+    ----------
+    x:        n x (k-1) matrix for x variables
+    beta:     k length list of regression coefficients
+    
+    Returns:
+    --------
+    xb:        nx1 vector of x times beta
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> from spreg import make_x, make_xb
+    >>> rng = np.random.default_rng(12345)
+    >>> x = make_x(rng,5,mu=[0,1],varu=[1,4])
+    >>> make_xb(x,[1,2,3])
+    array([[ 9.49243776],
+           [15.63018007],
+           [10.4055071 ],
+           [19.66820159],
+           [23.28469141]])
+    """
+    n = x.shape[0]
+    k = x.shape[1]
+    if k+1 != len(beta):
+        print("Error: Incompatible dimensions")
+        return None
+    else:
+        b = np.array(beta)[:,np.newaxis]
+        x1=np.hstack((np.ones((n,1)),x)) # include constant
+        xb = np.dot(x1,b)
+        return xb
+    
+def make_wxg(wx,gamma):
+    """
+    make_wxg: generate a column wxg as matrix wx (no constant)  
+             times list gamma (coefficient of spatially lagged x)
+    
+    Arguments:
+    ----------
+    wx:       n x ((k-1)xo) matrix for spatially lagged x variables of all orders
+    gamma:    (k-1)*o length list of regression coefficients for spatially lagged x
+    
+    Returns:
+    --------
+    wxg:      nx1 vector of wx times gamma
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_wx, make_wxg
+    >>> rng = np.random.default_rng(12345)
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> wx = make_wx(x,w)
+    >>> print(wx.shape)
+    (25, 1)
+    >>> make_wxg(wx,[2,4])[0:5,:]
+    array([[ 2.25018434,  4.50036868],
+           [ 3.74818158,  7.49636316],
+           [ 2.72450944,  5.44901889],
+           [ 4.298329  ,  8.59665799],
+           [ 5.60511572, 11.21023145]])
+
+    """
+    k = wx.shape[1]
+    if (k > 1): 
+        if k != len(gamma):
+            print("Error: Incompatible dimensions")
+            return None
+        else:
+            g = np.array(gamma)[:,np.newaxis]
+            wxg = np.dot(wx,g)
+    else:  # gamma is a scalar
+        wxg = wx * gamma
+    return wxg
+
+def dgp_errproc(u,w,lam=0.5,model='sar',imethod='power_exp'):
+    """
+    dgp_sar: generates pure spatial error process
+
+    Arguments:
+    ----------
+    u:      random error vector
+    w:      spatial weights object
+    lam:    spatial autoregressive parameter
+    model:  type of process ('sar' or 'ma')
+    imethod: method for inverse transformation, default = 'power_exp'
+
+    Returns:
+    --------
+    y : vector of observations following a pure SAR process
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, dgp_errproc
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> dgp_errproc(u,w)[0:5,:]
+    array([[-1.43760658],
+           [ 0.69778271],
+           [-0.7750646 ],
+           [-0.47750452],
+           [-0.72377417]])
+
+    """
+    n0 = u.shape[0]
+    if w.n != n0:
+        print("Error: incompatible weights dimensions")
+        return None
+    if model == 'sar':
+        y = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+    elif model == 'ma':
+        y = u + lam * libpysal.weights.lag_spatial(w,u)
+    else:
+        print("Error: unsupported model type")
+        return None
+    return y
+    
+
+def dgp_ols(u,xb):
+    """
+    dgp_ols: generates y for non-spatial process with given xb and error term u
+    
+    Arguments:
+    ----------
+    u:      random error vector
+    xb:     vector of xb
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, dgp_ols
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> dgp_ols(u,xb)[0:5,:]
+    array([[5.22803968],
+           [3.60291127],
+           [1.02632633],
+           [1.37589879],
+           [5.07165754]])
+
+    """
+    n1 = u.shape[0]
+    n2 = xb.shape[0]  
+    if n1 != n2:
+        print("Error: dimension mismatch")
+        return None
+    y = xb + u
+    return y
+
+def dgp_slx(u,xb,wxg):
+    """
+    dgp_slx: generates y for SLX with given xb, wxg, and error term u
+    
+    Arguments:
+    ----------
+    u:      random error vector
+    xb:     vector of xb
+    wxg:    vector of wxg
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_xb, make_wx, make_wxg, dgp_slx
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> wx = make_wx(x,w)
+    >>> wxg = make_wxg(wx,[2])
+    >>> dgp_slx(u, xb, wxg)[0:5,:]
+    array([[8.85854389],
+           [7.17524694],
+           [3.83674621],
+           [4.73103929],
+           [8.37023076]])
+    """
+    n0 = u.shape[0]
+    n1 = xb.shape[0]  
+    n2 = wxg.shape[0]
+    if n0 != n1:
+        print("Error: dimension mismatch")
+        return None
+    elif n1 != n2:
+        print("Error: dimension mismatch")
+        return None
+    y = xb + wxg + u
+    return y    
+    
+def dgp_sperror(u,xb,w,lam=0.5,model='sar',imethod='power_exp'):
+    """
+    dgp_sperror: generates y for spatial error model with given xb, weights,
+                  spatial parameter lam, error term, method for inverse transform
+    
+    Arguments:
+    ----------
+    u:       random error
+    xb:      vector of xb
+    w:       spatial weights
+    lam:     spatial coefficient
+    model:   type of process ('sar' or 'ma')
+    imethod: method for inverse transformation, default = 'power_exp'
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_xb, dgp_sperror
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> dgp_sperror(u, xb, w)[0:5,:]
+    array([[5.21425813],
+           [3.03696553],
+           [1.12192347],
+           [1.15756751],
+           [4.42322667]])
+    """
+    n0 = u.shape[0]
+    n1 = xb.shape[0]
+    if n0 != n1:
+        print("Error: incompatible weights dimensions")
+        return None
+    elif w.n != n1:
+        print("Error: incompatible weights dimensions")
+        return None
+    if model == 'sar':
+        u1 = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+    elif model == 'ma':
+        u1 = u + lam * libpysal.weights.lag_spatial(w,u)
+    else:
+        print("Error: unsupported model type")
+        return None
+    y = xb + u1
+    return y
+
+def dgp_slxerror(u,xb,wxg,w,lam=0.5,model='sar',imethod='power_exp'):
+    """
+    dgp_sperror: generates y for SLX spatial error model with xb, wxg, weights,
+                  spatial parameter lam, model type (sar or ma),
+                  error term, method for inverse transform
+    
+    Arguments:
+    ----------
+    u:       random error
+    xb:      vector of xb
+    wxg:     vector of wxg
+    w:       spatial weights
+    lam:     spatial coefficient
+    model:   type of process ('sar' or 'ma')
+    imethod: method for inverse transformation, default = 'power_exp'
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_xb, make_wx, make_wxg, dgp_slxerror
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> wx = make_wx(x,w)
+    >>> wxg = make_wxg(wx,[2])
+    >>> dgp_slxerror(u,xb,wxg,w)[0:5,:]
+    array([[8.84476235],
+           [6.6093012 ],
+           [3.93234334],
+           [4.51270801],
+           [7.7217999 ]])
+   """
+    
+    n0 = u.shape[0]
+    n1 = xb.shape[0]  
+    n2 = wxg.shape[0]
+    if n0 != n1:
+        print("Error: dimension mismatch")
+        return None
+    elif n1 != n2:
+        print("Error: dimension mismatch")
+        return None
+    if w.n != n1:
+        print("Error: incompatible weights dimensions")
+        return None
+    if model == 'sar':
+        u1 = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+    elif model == 'ma':
+        u1 = u + lam * libpysal.weights.lag_spatial(w,u)
+    else:
+        print("Error: unsupported model type")
+        return None  
+    y = xb + wxg + u1
+    return y
+    
+def dgp_lag(u,xb,w,rho=0.5,imethod='power_exp'):
+    """
+    dgp_lag:      generates y for spatial lag model with xb, weights,
+                  spatial parameter rho,
+                  error term, method for inverse transform
+    
+    Arguments:
+    ----------
+    u:       random error
+    xb:      vector of xb
+    w:       spatial weights
+    rho:     spatial coefficient
+    imethod: method for inverse transformation, default = 'power_exp'
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_xb, dgp_lag
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> dgp_lag(u, xb, w)[0:5,:]
+    array([[10.16582326],
+           [ 7.75359864],
+           [ 5.39821733],
+           [ 5.62244672],
+           [ 8.868168  ]])
+   """    
+    n0 = u.shape[0]
+    n1 = xb.shape[0]
+    if n0 != n1:
+        print("Error: dimension mismatch")
+        return None
+    if w.n != n1:
+        print("Error: incompatible weights dimensions")
+        return None
+    y1 = xb + u
+    y = spreg.utils.inverse_prod(w,y1,rho,inv_method=imethod)
+    return y
+    
+def dgp_spdurbin(u,xb,wxg,w,rho=0.5,imethod='power_exp'):
+    """
+    dgp_spdurbin: generates y for spatial Durbin model with xb, wxg, weights,
+                  spatial parameter rho,
+                  error term, method for inverse transform
+    
+    Arguments:
+    ----------
+    u:       random error
+    xb:      vector of xb
+    wxg:     vector of wxg
+    w:       spatial weights
+    rho:     spatial coefficient
+    imethod: method for inverse transformation, default = 'power_exp'
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_xb, make_wx, make_wxg, dgp_spdurbin
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> wx = make_wx(x,w)
+    >>> wxg = make_wxg(wx,[2])
+    >>> dgp_spdurbin(u,xb,wxg,w)[0:5,:]
+    array([[18.06895353],
+           [15.18686487],
+           [11.95080505],
+           [12.55220513],
+           [15.75805066]])
+   """        
+    n0 = u.shape[0]
+    n1 = xb.shape[0]  
+    n2 = wxg.shape[0]
+    if n0 != n1:
+        print("Error: dimension mismatch")
+        return None
+    elif n1 != n2:
+        print("Error: dimension mismatch")
+        return None
+    if w.n != n1:
+        print("Error: incompatible weights dimensions")
+    y1 = xb + wxg + u
+    y = spreg.utils.inverse_prod(w,y1,rho,inv_method=imethod)
+    return y
+    
+def dgp_lagerr(u,xb,w,rho=0.5,lam=0.2,model='sar',imethod='power_exp'):
+    """
+    dgp_lagerr:   generates y for spatial lag model with sar or ma errors
+                  with xb, weights,
+                  spatial parameter rho, spatial parameter lambda,
+                  model for spatial process,
+                  error term, method for inverse transform
+    
+    Arguments:
+    ----------
+    u:       random error
+    xb:      vector of xb
+    w:       spatial weights
+    rho:     spatial coefficient for lag
+    lam:     spatial coefficient for error
+    model:   spatial process for error
+    imethod: method for inverse transformation, default = 'power_exp'
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_xb, dgp_lagerr
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> dgp_lagerr(u, xb, w)[0:5,:]
+    array([[10.13845523],
+           [ 7.53009531],
+           [ 5.40644034],
+           [ 5.51132886],
+           [ 8.58872366]])
+   """            
+    n0 = u.shape[0]
+    n1 = xb.shape[0]
+    if n0 != n1:
+        print("Error: dimension mismatch")
+        return None
+    if w.n != n1:
+        print("Error: incompatible weights dimensions")
+        return None
+    if model == 'sar':
+        u1 = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+    elif model == 'ma':
+        u1 = u + lam * libpysal.weights.lag_spatial(w,u)
+    else:
+        print("Error: unsupported model type")
+        return None
+    y1 = xb + u1
+    y = spreg.utils.inverse_prod(w,y1,rho,inv_method=imethod)
+    return y
+    
+def dgp_gns(u,xb,wxg,w,rho=0.5,lam=0.2,model='sar',imethod='power_exp'):
+    """
+    dgp_gns:      generates y for general nested model with sar or ma errors
+                  with xb, wxg, weights,
+                  spatial parameter rho, spatial parameter lambda,
+                  model for spatial process,
+                  error term, method for inverse transform
+    
+    Arguments:
+    ----------
+    u:       random error
+    xb:      vector of xb
+    wxg:     vector of wxg
+    w:       spatial weights
+    rho:     spatial coefficient for lag
+    lam:     spatial coefficient for error
+    model:   spatial process for error
+    imethod: method for inverse transformation, default = 'power_exp'
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_xb, make_wx, make_wxg, dgp_gns
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> wx = make_wx(x,w)
+    >>> wxg = make_wxg(wx,[2])
+    >>> dgp_gns(u,xb,wxg,w)[0:5,:]
+    array([[18.04158549],
+           [14.96336153],
+           [11.95902806],
+           [12.44108728],
+           [15.47860632]])
+   """            
+    n0 = u.shape[0]
+    n1 = xb.shape[0]  
+    n2 = wxg.shape[0]
+    if n0 != n1:
+        print("Error: dimension mismatch")
+        return None       
+    elif n1 != n2:
+        print("Error: dimension mismatch")
+        return None
+    if w.n != n1:
+        print("Error: incompatible weights dimensions")
+    if model == 'sar':
+        u1 = spreg.utils.inverse_prod(w,u,lam,inv_method=imethod)
+    elif model == 'ma':
+        u1 = u + lam * libpysal.weights.lag_spatial(w,u)
+    else:
+        print("Error: unsupported model type")
+        return None
+    y1 = xb + wxg + u1
+    y = spreg.utils.inverse_prod(w,y1,rho,inv_method=imethod)
+    return y
+    
+def dgp_mess(u,xb,w,rho=0.5):
+    """
+    dgp_mess:     generates y for MESS spatial lag model with xb, weights,
+                  spatial parameter rho (gets converted into alpha),
+                  sigma/method for the error term
+    
+    Arguments:
+    ----------
+    u:       random error
+    xb:      vector of xb
+    w:       spatial weights
+    rho:     spatial coefficient (converted into alpha)
+    
+    Returns:
+    ----------
+    y: vector of observations on dependent variable
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import libpysal
+    >>> from spreg import make_x, make_xb, dgp_mess
+    >>> rng = np.random.default_rng(12345)
+    >>> u = make_x(rng,25,mu=[0],varu=[1], method='normal')
+    >>> x = make_x(rng,25,mu=[0],varu=[1])
+    >>> xb = make_xb(x,[1,2])
+    >>> w  = libpysal.weights.lat2W(5, 5)
+    >>> w.transform = "r"
+    >>> dgp_mess(u, xb, w)[0:5,:]
+    array([[10.12104421],
+           [ 7.45561055],
+           [ 5.32807674],
+           [ 5.55549492],
+           [ 8.62685145]])
+   """        
+    n0 = u.shape[0]
+    n1 = xb.shape[0]
+    if n0 != n1:
+        print("Error: dimension mismatch")
+        return None    
+    if w.n != n1:
+        print("Error: incompatible weights dimensions")
+        return None
+    bigw = libpysal.weights.full(w)[0]
+    alpha=np.log(1-rho) #convert between rho and alpha
+    aw=-alpha*bigw      # inverse exponential is -alpha
+    xbu = xb + u
+    y = np.dot(expm(aw),xbu)
+    return y
+
+def _test():
+    import doctest
+
+    start_suppress = np.get_printoptions()["suppress"]
+    np.set_printoptions(suppress=True)
+    doctest.testmod()
+    np.set_printoptions(suppress=start_suppress)
+
+if __name__ == "__main__":
+    _test()
+    

--- a/spreg/error_sp.py
+++ b/spreg/error_sp.py
@@ -135,7 +135,7 @@ class GM_Error(BaseGM_Error):
                    Spatial weights object (always needed)
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results
@@ -307,7 +307,7 @@ class GM_Error(BaseGM_Error):
             x_constant = np.hstack((x_constant, lag_x))
 #            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
             name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags) # exclude constant
-            self.title += " WITH SLX (SDEM)"
+            self.title += " WITH SLX (SLX-Error)"
         
         BaseGM_Error.__init__(self, y=y, x=x_constant, w=w.sparse, hard_bound=hard_bound)
         self.name_ds = USER.set_name_ds(name_ds)
@@ -459,7 +459,7 @@ class GM_Endog_Error(BaseGM_Endog_Error):
                    Spatial weights object (always needed)
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results
@@ -671,7 +671,7 @@ class GM_Endog_Error(BaseGM_Endog_Error):
             x_constant = np.hstack((x_constant, lag_x))
 #            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
             name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags)  # exclude constant
-            self.title += " WITH SLX (SDEM)"        
+            self.title += " WITH SLX (SLX-Error)"        
         BaseGM_Endog_Error.__init__(self, y=y, x=x_constant, w=w.sparse, yend=yend, q=q, hard_bound=hard_bound)
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
@@ -1029,7 +1029,7 @@ class GMM_Error(GM_Error, GM_Endog_Error, GM_Combo, GM_Error_Het, GM_Endog_Error
                    If True, then a spatial lag of the dependent variable is included.           
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM or GNSM type.             
+                   If slx_lags>0, the specification becomes of the SLX-Error or GNSM type.             
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results

--- a/spreg/error_sp.py
+++ b/spreg/error_sp.py
@@ -2,7 +2,7 @@
 Spatial Error Models module
 """
 
-__author__ = "Luc Anselin luc.anselin@asu.edu, \
+__author__ = "Luc Anselin lanselin@gmail.com, \
         Daniel Arribas-Bel darribas@asu.edu, \
         Pedro V. Amaral pedro.amaral@asu.edu"
 
@@ -37,7 +37,9 @@ class BaseGM_Error(RegressionPropsY):
                    independent (exogenous) variable, excluding the constant
     w            : Sparse matrix
                    Spatial weights sparse matrix
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     betas        : array
@@ -87,7 +89,7 @@ class BaseGM_Error(RegressionPropsY):
            [ 0.3257]])
     """
 
-    def __init__(self, y, x, w):
+    def __init__(self, y, x, w, hard_bound=False):
 
         # 1a. OLS --> \tilde{betas}
         ols = OLS.BaseOLS(y=y, x=x)
@@ -97,7 +99,7 @@ class BaseGM_Error(RegressionPropsY):
 
         # 1b. GMM --> \tilde{\lambda1}
         moments = _momentsGM_Error(w, ols.u)
-        lambda1 = optim_moments(moments)
+        lambda1 = optim_moments(moments, hard_bound=hard_bound)
 
         # 2a. OLS -->\hat{betas}
         xs = get_spFilter(w, lambda1, self.x)
@@ -147,7 +149,9 @@ class GM_Error(BaseGM_Error):
                    Name of dataset for use in output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -287,26 +291,29 @@ class GM_Error(BaseGM_Error):
     """
 
     def __init__(
-        self, y, x, w, slx_lags=0, vm=False, name_y=None, name_x=None, name_w=None, name_ds=None, latex=False
-    ):
+        self, y, x, w, slx_lags=0, vm=False, name_y=None, name_x=None, name_w=None, name_ds=None, latex=False,
+            hard_bound=False):
 
         n = USER.check_arrays(y, x)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
+        name_x = USER.set_name_x(name_x, x_constant)  # intialize in case of None, contains constant
         set_warn(self, warn)
         
         self.title = "GM SPATIALLY WEIGHTED LEAST SQUARES"
         if slx_lags >0:
             lag_x = get_lags(w, x_constant[:, 1:], slx_lags)
             x_constant = np.hstack((x_constant, lag_x))
-            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+#            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags) # exclude constant
             self.title += " WITH SLX (SDEM)"
         
-        BaseGM_Error.__init__(self, y=y, x=x_constant, w=w.sparse)
+        BaseGM_Error.__init__(self, y=y, x=x_constant, w=w.sparse, hard_bound=hard_bound)
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x_constant)
+#        self.name_x = USER.set_name_x(name_x, x_constant)
+        self.name_x = name_x  # already includes constant
         self.name_x.append("lambda")
         self.name_w = USER.set_name_w(name_w, w)
         self.output = pd.DataFrame(self.name_x, columns=['var_names'])
@@ -338,7 +345,9 @@ class BaseGM_Endog_Error(RegressionPropsY):
                    this should not contain any variables from x)
     w            : Sparse matrix
                    Spatial weights sparse matrix
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     betas        : array
@@ -396,7 +405,7 @@ class BaseGM_Endog_Error(RegressionPropsY):
 
     """
 
-    def __init__(self, y, x, yend, q, w):
+    def __init__(self, y, x, yend, q, w, hard_bound=False):
 
         # 1a. TSLS --> \tilde{betas}
         tsls = TSLS.BaseTSLS(y=y, x=x, yend=yend, q=q)
@@ -407,7 +416,7 @@ class BaseGM_Endog_Error(RegressionPropsY):
 
         # 1b. GMM --> \tilde{\lambda1}
         moments = _momentsGM_Error(w, tsls.u)
-        lambda1 = optim_moments(moments)
+        lambda1 = optim_moments(moments, hard_bound=hard_bound)
 
         # 2a. 2SLS -->\hat{betas}
         xs = get_spFilter(w, lambda1, self.x)
@@ -468,7 +477,9 @@ class GM_Endog_Error(BaseGM_Endog_Error):
                    Name of dataset for use in output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -645,23 +656,27 @@ class GM_Endog_Error(BaseGM_Endog_Error):
         name_w=None,
         name_ds=None,
         latex=False,
+        hard_bound=False,
     ):
 
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
+        name_x = USER.set_name_x(name_x, x_constant) # initialize for None, includes constant
         set_warn(self, warn)
         self.title = "GM SPATIALLY WEIGHTED TWO STAGE LEAST SQUARES"
         if slx_lags >0:
             lag_x = get_lags(w, x_constant[:, 1:], slx_lags)
             x_constant = np.hstack((x_constant, lag_x))
-            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+#            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags)  # exclude constant
             self.title += " WITH SLX (SDEM)"        
-        BaseGM_Endog_Error.__init__(self, y=y, x=x_constant, w=w.sparse, yend=yend, q=q)
+        BaseGM_Endog_Error.__init__(self, y=y, x=x_constant, w=w.sparse, yend=yend, q=q, hard_bound=hard_bound)
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x_constant)
+#        self.name_x = USER.set_name_x(name_x, x_constant)
+        self.name_x = name_x  # already includes constant
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_z = self.name_x + self.name_yend
         self.name_z.append("lambda")
@@ -726,7 +741,9 @@ class GM_Combo(BaseGM_Endog_Error):
                    Name of dataset for use in output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -934,12 +951,14 @@ class GM_Combo(BaseGM_Endog_Error):
         name_w=None,
         name_ds=None,
         latex=False,
+        hard_bound=False,
     ):
 
         n = USER.check_arrays(y, x, yend, q)
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
+        name_x = USER.set_name_x(name_x, x_constant)
         set_warn(self, warn)
         if slx_lags == 0:
             yend2, q2 = set_endog(y, x_constant[:, 1:], w, yend, q, w_lags, lag_q)
@@ -947,7 +966,7 @@ class GM_Combo(BaseGM_Endog_Error):
             yend2, q2, wx = set_endog(y, x_constant[:, 1:], w, yend, q, w_lags, lag_q, slx_lags)
             x_constant = np.hstack((x_constant, wx))
 
-        BaseGM_Endog_Error.__init__(self, y=y, x=x_constant, w=w.sparse, yend=yend2, q=q2)
+        BaseGM_Endog_Error.__init__(self, y=y, x=x_constant, w=w.sparse, yend=yend2, q=q2, hard_bound=hard_bound)
 
         self.rho = self.betas[-2]
         self.predy_e, self.e_pred, warn = sp_att(
@@ -956,11 +975,13 @@ class GM_Combo(BaseGM_Endog_Error):
         set_warn(self, warn)
         self.title = "SPATIALLY WEIGHTED 2SLS - GM-COMBO MODEL"
         if slx_lags > 0:
-            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+#            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags)   # exclude constant
             self.title += " WITH SLX (GNSM)"
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x_constant)
+#        self.name_x = USER.set_name_x(name_x, x_constant)
+        self.name_x = name_x  # constant already in list
         self.name_yend = USER.set_name_yend(name_yend, yend)
         self.name_yend.append(USER.set_name_yend_sp(self.name_y))
         self.name_z = self.name_x + self.name_yend
@@ -1026,6 +1047,9 @@ class GMM_Error(GM_Error, GM_Endog_Error, GM_Combo, GM_Error_Het, GM_Endog_Error
                    Name of dataset for use in output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     **kwargs     : keywords
                    Additional arguments to pass on to the estimators. 
                    See the specific functions for details on what can be used.
@@ -1209,54 +1233,54 @@ class GMM_Error(GM_Error, GM_Endog_Error, GM_Combo, GM_Error_Het, GM_Endog_Error
 
     def __init__(
         self, y, x, w, yend=None, q=None, estimator='het', add_wy=False, slx_lags=0, vm=False, name_y=None, name_x=None, name_w=None, name_yend=None,
-        name_q=None, name_ds=None, latex=False, **kwargs):
+        name_q=None, name_ds=None, latex=False, hard_bound=False, **kwargs):
 
         if estimator == 'het':
             if yend is None and not add_wy:
                 GM_Error_Het.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
-                                      name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                      name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             elif yend is not None and not add_wy:
                 GM_Endog_Error_Het.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
-                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             elif add_wy:
                 GM_Combo_Het.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
-                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             else:
                 set_warn(self, 'Combination of arguments passed to GMM_Error not allowed. Using default arguments instead.')
                 GM_Error_Het.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
-                                      name_w=name_w, name_ds=name_ds, latex=latex)
+                                      name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound)
         elif estimator == 'hom':
             if yend is None and not add_wy:
                 GM_Error_Hom.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
-                                      name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                      name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             elif yend is not None and not add_wy:
                 GM_Endog_Error_Hom.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
-                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             elif add_wy:
                 GM_Combo_Hom.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
-                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             else:
                 set_warn(self, 'Combination of arguments passed to GMM_Error not allowed. Using default arguments instead.')
                 GM_Error_Hom.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
-                                      name_w=name_w, name_ds=name_ds, latex=latex)
+                                      name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound)
         elif estimator == 'kp98':
             if yend is None and not add_wy:
                 GM_Error.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
-                                      name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                      name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             elif yend is not None and not add_wy:
                 GM_Endog_Error.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
-                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             elif add_wy:
                 GM_Combo.__init__(self, y=y, x=x, yend=yend, q=q, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x,
-                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, **kwargs)
+                                            name_yend=name_yend, name_q=name_q, name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound, **kwargs)
             else:
                 set_warn(self, 'Combination of arguments passed to GMM_Error not allowed. Using default arguments instead.')
                 GM_Error.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
-                                      name_w=name_w, name_ds=name_ds, latex=latex)
+                                      name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound)
         else:
             set_warn(self, 'Combination of arguments passed to GMM_Error not allowed. Using default arguments instead.')
             GM_Error_Het.__init__(self, y=y, x=x, w=w, slx_lags=slx_lags, vm=vm, name_y=name_y, name_x=name_x, 
-                                    name_w=name_w, name_ds=name_ds, latex=latex)
+                                    name_w=name_w, name_ds=name_ds, latex=latex, hard_bound=hard_bound)
 
 
 def _momentsGM_Error(w, u):

--- a/spreg/error_sp_het.py
+++ b/spreg/error_sp_het.py
@@ -129,12 +129,6 @@ class BaseGM_Error_Het(RegressionPropsY):
         else:
             lambda2 = lambda1
 
-        # Forcing the 1st step lambda to be in the range [-0.9, 0.9] to avoid perfect collinearity in step 2 in case of SLX-Error or GNS models
-        #if lambda2 > 0.9:
-        #    lambda_old = 0.9
-        #elif lambda2 < -0.9:
-        #    lambda_old = -0.9
-        #else:
         lambda_old = lambda2
 
         self.iteration, eps = 0, 1

--- a/spreg/error_sp_het.py
+++ b/spreg/error_sp_het.py
@@ -188,7 +188,7 @@ class GM_Error_Het(BaseGM_Error_Het):
                    Spatial weights object
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from :cite:`Arraiz2010`.
                    Note: epsilon provides an additional
@@ -386,7 +386,7 @@ class GM_Error_Het(BaseGM_Error_Het):
             x_constant = np.hstack((x_constant, lag_x))
 #            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
             name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags)  # no constant
-            self.title += " WITH SLX (SDEM)"
+            self.title += " WITH SLX (SLX-Error)"
         BaseGM_Error_Het.__init__(
             self,
             y,
@@ -673,7 +673,7 @@ class GM_Endog_Error_Het(BaseGM_Endog_Error_Het):
                    Spatial weights object
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from
                    :cite:`Arraiz2010`. Note: epsilon provides an additional
@@ -913,7 +913,7 @@ class GM_Endog_Error_Het(BaseGM_Endog_Error_Het):
             lag_x = get_lags(w, x_constant[:, 1:], slx_lags)
             x_constant = np.hstack((x_constant, lag_x))
             name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags)    # no constant
-            self.title += " WITH SLX (SDEM)"
+            self.title += " WITH SLX (SLX-Error)"
         BaseGM_Endog_Error_Het.__init__(
             self,
             y=y,

--- a/spreg/error_sp_het_regimes.py
+++ b/spreg/error_sp_het_regimes.py
@@ -67,7 +67,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     Always False, kept for consistency, ignored.
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from Arraiz
                    et al. Note: epsilon provides an additional stop condition.
@@ -438,7 +438,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             if slx_lags == 0:
                 self.title = "GM SPATIALLY WEIGHTED MODEL (HET) - REGIMES"
             else:
-                self.title = "GM SPATIALLY WEIGHTED MODEL + SLX (SDEM-HET) - REGIMES"            
+                self.title = "GM SPATIALLY WEIGHTED MODEL + SLX (Error-HET) - REGIMES"            
             
             self.name_x.append("lambda")
             self.kf += 1
@@ -626,7 +626,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                      Always False, kept for consistency, ignored.
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from
                    :cite:`Arraiz2010`. Note: epsilon provides an additional stop condition.
@@ -1121,7 +1121,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 if slx_lags == 0:
                     self.title = ("GM SPATIALLY WEIGHTED 2SLS (HET) - REGIMES")
                 else:
-                    self.title = ("GM SPATIALLY WEIGHTED 2SLS + SLX (SDEM-HET) - REGIMES")
+                    self.title = ("GM SPATIALLY WEIGHTED 2SLS + SLX (Error-HET) - REGIMES")
                 output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
     def _endog_error_het_regimes_multi(
@@ -1837,7 +1837,7 @@ def _work_error(
     if slx_lags == 0:
         model.title = "GM SPATIALLY WEIGHTED LS (HET) - REGIME %s" % r
     else:
-        model.title = "GM SPATIALLY WEIGHTED LS + SLX (SDEM-HET) - REGIME %s" % r
+        model.title = "GM SPATIALLY WEIGHTED LS + SLX (Error-HET) - REGIME %s" % r
     model.name_ds = name_ds
     model.name_y = "%s_%s" % (str(r), name_y)
     model.name_x = ["%s_%s" % (str(r), i) for i in name_x]
@@ -1910,7 +1910,7 @@ def _work_endog_error(
         if add_lag != False:
             model.title = "GM SPATIAL COMBO MODEL + SLX (GNSM-HET) - REGIME %s" % r   
         else:
-            model.title = "GM SPATIALLY WEIGHTED 2SLS + SLX (SDEM-HET) - REGIME %s" % r
+            model.title = "GM SPATIALLY WEIGHTED 2SLS + SLX (Error-HET) - REGIME %s" % r
     model.name_ds = name_ds
     model.name_y = "%s_%s" % (str(r), name_y)
     model.name_x = ["%s_%s" % (str(r), i) for i in name_x]

--- a/spreg/error_sp_het_regimes.py
+++ b/spreg/error_sp_het_regimes.py
@@ -96,7 +96,9 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -321,6 +323,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         name_ds=None,
         name_regimes=None,
         latex=False,
+        hard_bound=False,
     ):
 
         n = USER.check_arrays(y, x)
@@ -369,6 +372,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     vm,
                     name_x,
                     latex,
+                    hard_bound,
                 )
             else:
                 raise Exception(
@@ -392,13 +396,13 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
 
             # 1b. GMM --> \tilde{\lambda1}
             moments = UTILS._moments2eqs(wA1, w.sparse, ols.u)
-            lambda1 = UTILS.optim_moments(moments)
+            lambda1 = UTILS.optim_moments(moments, hard_bound=hard_bound)
 
             if step1c:
                 # 1c. GMM --> \tilde{\lambda2}
                 sigma = get_psi_sigma(w.sparse, ols.u, lambda1)
                 vc1 = get_vc_het(w.sparse, wA1, sigma)
-                lambda2 = UTILS.optim_moments(moments, vc1)
+                lambda2 = UTILS.optim_moments(moments, vc1, hard_bound=hard_bound)
             else:
                 lambda2 = lambda1
             lambda_old = lambda2
@@ -419,7 +423,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 sigma_i = get_psi_sigma(w.sparse, self.u, lambda_old)
                 vc_i = get_vc_het(w.sparse, wA1, sigma_i)
                 moments_i = UTILS._moments2eqs(wA1, w.sparse, self.u)
-                lambda3 = UTILS.optim_moments(moments_i, vc_i)
+                lambda3 = UTILS.optim_moments(moments_i, vc_i, hard_bound=hard_bound)
                 eps = abs(lambda3 - lambda_old)
                 lambda_old = lambda3
                 self.iteration += 1
@@ -449,7 +453,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
     def _error_het_regimes_multi(
-        self, y, x, regimes, w, slx_lags, cores, max_iter, epsilon, step1c, cols2regi, vm, name_x, latex
+        self, y, x, regimes, w, slx_lags, cores, max_iter, epsilon, step1c, cols2regi, vm, name_x, latex, hard_bound
     ):
 
         regi_ids = dict(
@@ -488,6 +492,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                         self.name_w,
                         self.name_regimes,
                         slx_lags,
+                        hard_bound,
                     ),
                 )
             else:
@@ -507,6 +512,7 @@ class GM_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                         self.name_w,
                         self.name_regimes,
                         slx_lags,
+                        hard_bound,
                     )
                 )
 
@@ -657,7 +663,9 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -927,6 +935,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         summ=True,
         add_lag=False,
         latex=False,
+        hard_bound=False,
     ):
 
         n = USER.check_arrays(y, x, yend, q)
@@ -984,6 +993,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     name_q,
                     add_lag,
                     latex,
+                    hard_bound,
                 )
             else:
                 raise Exception(
@@ -1024,7 +1034,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
 
             # 1b. GMM --> \tilde{\lambda1}
             moments = UTILS._moments2eqs(wA1, w.sparse, tsls.u)
-            lambda1 = UTILS.optim_moments(moments)
+            lambda1 = UTILS.optim_moments(moments, hard_bound=hard_bound)
 
             if step1c:
                 # 1c. GMM --> \tilde{\lambda2}
@@ -1040,7 +1050,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     inv_method,
                     filt=False,
                 )
-                lambda2 = UTILS.optim_moments(moments, vc1)
+                lambda2 = UTILS.optim_moments(moments, vc1, hard_bound=hard_bound)
             else:
                 lambda2 = lambda1
             lambda_old = lambda2
@@ -1077,7 +1087,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     inv_method,
                 )
                 moments_i = UTILS._moments2eqs(wA1, w.sparse, self.u)
-                lambda3 = UTILS.optim_moments(moments_i, vc2)
+                lambda3 = UTILS.optim_moments(moments_i, vc2, hard_bound=hard_bound)
                 eps = abs(lambda3 - lambda_old)
                 lambda_old = lambda3
                 self.iteration += 1
@@ -1135,6 +1145,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         name_q,
         add_lag,
         latex,
+        hard_bound,
     ):
 
         regi_ids = dict(
@@ -1184,6 +1195,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                         self.name_regimes,
                         add_lag,
                         slx_lags,
+                        hard_bound,
                     ),
                 )
             else:
@@ -1209,6 +1221,7 @@ class GM_Endog_Error_Het_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                         self.name_regimes,
                         add_lag,
                         slx_lags,
+                        hard_bound,
                     )
                 )
 
@@ -1388,7 +1401,9 @@ class GM_Combo_Het_Regimes(GM_Endog_Error_Het_Regimes):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -1691,6 +1706,7 @@ class GM_Combo_Het_Regimes(GM_Endog_Error_Het_Regimes):
         name_ds=None,
         name_regimes=None,
         latex=False,
+        hard_bound=False,
     ):
         if regime_lag_sep and not regime_err_sep:
             set_warn(self, "regime_err_sep set to True when regime_lag_sep=True.")                
@@ -1773,6 +1789,7 @@ class GM_Combo_Het_Regimes(GM_Endog_Error_Het_Regimes):
             summ=False,
             add_lag=add_lag,
             latex=latex,
+            hard_bound=hard_bound,
         )
 
         if regime_err_sep != True:
@@ -1807,12 +1824,13 @@ def _work_error(
     name_w,
     name_regimes,
     slx_lags,
+    hard_bound,
 ):
     w_r, warn = REGI.w_regime(w, regi_ids[r], r, transform=True)
     y_r = y[regi_ids[r]]
     x_r = x[regi_ids[r]]
     model = BaseGM_Error_Het(
-        y_r, x_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, step1c=step1c
+        y_r, x_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, step1c=step1c, hard_bound=hard_bound,
     )
     set_warn(model, warn)
     model.w = w_r
@@ -1849,6 +1867,7 @@ def _work_endog_error(
     name_regimes,
     add_lag,
     slx_lags,
+    hard_bound,
 ):
     w_r, warn = REGI.w_regime(w, regi_ids[r], r, transform=True)
     y_r = y[regi_ids[r]]
@@ -1872,6 +1891,7 @@ def _work_endog_error(
         epsilon=epsilon,
         step1c=step1c,
         inv_method=inv_method,
+        hard_bound=hard_bound,
     )
     set_warn(model, warn)
     if add_lag != False:

--- a/spreg/error_sp_hom.py
+++ b/spreg/error_sp_hom.py
@@ -182,7 +182,7 @@ class GM_Error_Hom(BaseGM_Error_Hom):
                    Spatial weights object
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from :cite:`Arraiz2010`.
                    Note: epsilon provides an additional stop condition.
@@ -376,7 +376,7 @@ class GM_Error_Hom(BaseGM_Error_Hom):
             x_constant = np.hstack((x_constant, lag_x))
 #            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
             name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags)  # exclude constant
-            self.title += " WITH SLX (SDEM)"        
+            self.title += " WITH SLX (SLX-Error)"        
         BaseGM_Error_Hom.__init__(
             self,
             y=y,
@@ -595,7 +595,7 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
                    Spatial weights object
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.                   
+                   If slx_lags>0, the specification becomes of the SLX-Error type.                   
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from
                    :cite:`Arraiz2010`. Note: epsilon provides an additional stop condition.
@@ -834,7 +834,7 @@ class GM_Endog_Error_Hom(BaseGM_Endog_Error_Hom):
             x_constant = np.hstack((x_constant, lag_x))
 #            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
             name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags)  # exclude constant
-            self.title += " WITH SLX (SDEM)"
+            self.title += " WITH SLX (SLX-Error)"
         BaseGM_Endog_Error_Hom.__init__(
             self,
             y=y,

--- a/spreg/error_sp_hom_regimes.py
+++ b/spreg/error_sp_hom_regimes.py
@@ -102,7 +102,9 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -332,6 +334,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         name_ds=None,
         name_regimes=None,
         latex=False,
+        hard_bound=False,
     ):
 
         n = USER.check_arrays(y, x)
@@ -380,6 +383,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     vm,
                     name_x,
                     latex,
+                    hard_bound,
                 )
             else:
                 raise Exception(
@@ -412,7 +416,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
 
             # 1b. GM --> \tilde{\rho}
             moments = moments_hom(w.sparse, wA1, wA2, ols.u)
-            lambda1 = optim_moments(moments)
+            lambda1 = optim_moments(moments, hard_bound=hard_bound)
             lambda_old = lambda1
 
             self.iteration, eps = 0, 1
@@ -430,7 +434,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 # 2b. GM 2nd iteration --> \hat{\rho}
                 moments = moments_hom(w.sparse, wA1, wA2, self.u)
                 psi = get_vc_hom(w.sparse, wA1, wA2, self, lambda_old)[0]
-                lambda2 = optim_moments(moments, psi)
+                lambda2 = optim_moments(moments, psi, hard_bound=hard_bound)
                 eps = abs(lambda2 - lambda_old)
                 lambda_old = lambda2
                 self.iteration += 1
@@ -461,7 +465,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
     def _error_hom_regimes_multi(
-        self, y, x, regimes, w, slx_lags, cores, max_iter, epsilon, A1, cols2regi, vm, name_x, latex):
+        self, y, x, regimes, w, slx_lags, cores, max_iter, epsilon, A1, cols2regi, vm, name_x, latex, hard_bound):
 
         regi_ids = dict(
             (r, list(np.where(np.array(regimes) == r)[0])) for r in self.regimes_set
@@ -499,6 +503,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                         self.name_w,
                         self.name_regimes,
                         slx_lags,
+                        hard_bound,
                     ),
                 )
             else:
@@ -518,6 +523,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                         self.name_w,
                         self.name_regimes,
                         slx_lags,
+                        hard_bound,
                     )
                 )
 
@@ -665,7 +671,9 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -943,6 +951,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         summ=True,
         add_lag=False,
         latex=False,
+        hard_bound=False,
     ):
 
         n = USER.check_arrays(y, x, yend, q)
@@ -999,6 +1008,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     name_q,
                     add_lag,
                     latex,
+                    hard_bound,
                 )
             else:
                 raise Exception(
@@ -1046,7 +1056,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
 
             # 1b. GM --> \tilde{\rho}
             moments = moments_hom(w.sparse, wA1, wA2, tsls.u)
-            lambda1 = optim_moments(moments)
+            lambda1 = optim_moments(moments, hard_bound=hard_bound)
             lambda_old = lambda1
 
             self.iteration, eps = 0, 1
@@ -1073,7 +1083,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 # 2b. GM 2nd iteration --> \hat{\rho}
                 moments = moments_hom(w.sparse, wA1, wA2, self.u)
                 psi = get_vc_hom(w.sparse, wA1, wA2, self, lambda_old, tsls_s.z)[0]
-                lambda2 = optim_moments(moments, psi)
+                lambda2 = optim_moments(moments, psi, hard_bound=hard_bound)
                 eps = abs(lambda2 - lambda_old)
                 lambda_old = lambda2
                 self.iteration += 1
@@ -1129,6 +1139,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
         name_q,
         add_lag,
         latex,
+        hard_bound,
     ):
 
         regi_ids = dict(
@@ -1177,6 +1188,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                         self.name_regimes,
                         add_lag,
                         slx_lags,
+                        hard_bound,
                     ),
                 )
             else:
@@ -1201,6 +1213,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                         self.name_regimes,
                         add_lag,
                         slx_lags,
+                        hard_bound,
                     )
                 )
 
@@ -1381,7 +1394,9 @@ class GM_Combo_Hom_Regimes(GM_Endog_Error_Hom_Regimes):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -1689,6 +1704,7 @@ class GM_Combo_Hom_Regimes(GM_Endog_Error_Hom_Regimes):
         name_ds=None,
         name_regimes=None,
         latex=False,
+        hard_bound=False,
     ):
 
         if regime_lag_sep and not regime_err_sep:
@@ -1771,6 +1787,7 @@ class GM_Combo_Hom_Regimes(GM_Endog_Error_Hom_Regimes):
             summ=False,
             add_lag=add_lag,
             latex=latex,
+            hard_bound=hard_bound,
         )
 
         if regime_err_sep != True:
@@ -1805,12 +1822,13 @@ def _work_error(
     name_w,
     name_regimes,
     slx_lags,
+    hard_bound,
 ):
     w_r, warn = REGI.w_regime(w, regi_ids[r], r, transform=True)
     y_r = y[regi_ids[r]]
     x_r = x[regi_ids[r]]
     model = BaseGM_Error_Hom(
-        y_r, x_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, A1=A1
+        y_r, x_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, A1=A1, hard_bound=hard_bound,
     )
     set_warn(model, warn)
     model.w = w_r
@@ -1846,6 +1864,7 @@ def _work_endog_error(
     name_regimes,
     add_lag,
     slx_lags,
+    hard_bound,
 ):
     w_r, warn = REGI.w_regime(w, regi_ids[r], r, transform=True)
     y_r = y[regi_ids[r]]
@@ -1861,7 +1880,7 @@ def _work_endog_error(
         )
     x_constant = USER.check_constant(x_r)
     model = BaseGM_Endog_Error_Hom(
-        y_r, x_r, yend_r, q_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, A1=A1
+        y_r, x_r, yend_r, q_r, w_r.sparse, max_iter=max_iter, epsilon=epsilon, A1=A1, hard_bound=hard_bound,
     )
     set_warn(model, warn)
     if add_lag != False:

--- a/spreg/error_sp_hom_regimes.py
+++ b/spreg/error_sp_hom_regimes.py
@@ -69,7 +69,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     Always False, kept for consistency, ignored.
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from
                    :cite:`Arraiz2010`. Note: epsilon provides an additional
@@ -450,7 +450,7 @@ class GM_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             if slx_lags == 0:
                 self.title = "GM SPATIALLY WEIGHTED MODEL (HOM) - REGIMES"
             else:
-                self.title = "GM SPATIALLY WEIGHTED MODEL + SLX (SDEM-HOM) - REGIMES"          
+                self.title = "GM SPATIALLY WEIGHTED MODEL + SLX (Error-HOM) - REGIMES"          
             self.name_x.append("lambda")
             self.kf += 1
             self.chow = REGI.Chow(self)
@@ -638,7 +638,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                      Always False, kept for consistency, ignored.
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     max_iter     : int
                    Maximum number of iterations of steps 2a and 2b from
                    :cite:`Arraiz2010`. Note: epsilon provides an additional stop condition.
@@ -1116,7 +1116,7 @@ class GM_Endog_Error_Hom_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 if slx_lags == 0:
                     self.title = ("GM SPATIALLY WEIGHTED 2SLS (HOM) - REGIMES")
                 else:
-                    self.title = ("GM SPATIALLY WEIGHTED 2SLS WITH SLX (SDEM-HOM) - REGIMES")
+                    self.title = ("GM SPATIALLY WEIGHTED 2SLS WITH SLX (Error-HOM) - REGIMES")
                 output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
     def _endog_error_hom_regimes_multi(
@@ -1835,7 +1835,7 @@ def _work_error(
     if slx_lags == 0:
         model.title = "GM SPATIALLY WEIGHTED 2SLS (HOM) - REGIME %s" % r
     else:
-        model.title = "GM SPATIALLY WEIGHTED 2SLS + SLX (SDEM-HOM) - REGIME %s" % r    
+        model.title = "GM SPATIALLY WEIGHTED 2SLS + SLX (Error-HOM) - REGIME %s" % r    
     model.name_ds = name_ds
     model.name_y = "%s_%s" % (str(r), name_y)
     model.name_x = ["%s_%s" % (str(r), i) for i in name_x]
@@ -1898,7 +1898,7 @@ def _work_endog_error(
         if add_lag != False:
             model.title = "GM SPATIAL COMBO MODEL + SLX (GNSM-HOM) - REGIME %s" % r   
         else:
-            model.title = "GM SPATIALLY WEIGHTED 2SLS + SLX (SDEM-HOM) - REGIME %s" % r
+            model.title = "GM SPATIALLY WEIGHTED 2SLS + SLX (Error-HOM) - REGIME %s" % r
     model.name_ds = name_ds
     model.name_y = "%s_%s" % (str(r), name_y)
     model.name_x = ["%s_%s" % (str(r), i) for i in name_x]

--- a/spreg/error_sp_regimes.py
+++ b/spreg/error_sp_regimes.py
@@ -80,7 +80,9 @@ class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -562,7 +564,9 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -1200,7 +1204,9 @@ class GM_Combo_Regimes(GM_Endog_Error_Regimes, REGI.Regimes_Frame):
                    Name of regime variable for use in the output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     Attributes
     ----------
     output       : dataframe
@@ -1654,6 +1660,9 @@ class GMM_Error_Regimes(GM_Error_Regimes, GM_Combo_Regimes, GM_Endog_Error_Regim
                    Name of dataset for use in output
     latex        : boolean
                    Specifies if summary is to be printed in latex format
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
     **kwargs     : keywords
                    Additional arguments to pass on to the estimators. 
                    See the specific functions for details on what can be used.

--- a/spreg/error_sp_regimes.py
+++ b/spreg/error_sp_regimes.py
@@ -60,7 +60,7 @@ class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     Always False, kept for consistency, ignored.
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results
@@ -366,7 +366,7 @@ class GM_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
             if slx_lags == 0:
                 self.title = "GM SPATIALLY WEIGHTED MODEL - REGIMES"
             else:
-                self.title = "GM SPATIALLY WEIGHTED MODEL + SLX (SDEM) - REGIMES"       
+                self.title = "GM SPATIALLY WEIGHTED MODEL + SLX (SLX-Error) - REGIMES"       
             self.name_x.append("lambda")
             self.kf += 1
             self.chow = REGI.Chow(self)
@@ -540,7 +540,7 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                     Always False, kept for consistency, ignored.
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.
+                   If slx_lags>0, the specification becomes of the SLX-Error type.
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results
@@ -949,7 +949,7 @@ class GM_Endog_Error_Regimes(RegressionPropsY, REGI.Regimes_Frame):
                 if slx_lags == 0:
                     self.title = ("GM SPATIALLY WEIGHTED 2SLS - REGIMES")
                 else:
-                    self.title = ("GM SPATIALLY WEIGHTED 2SLS WITH SLX (SDEM) - REGIMES")
+                    self.title = ("GM SPATIALLY WEIGHTED 2SLS WITH SLX (SLX-Error) - REGIMES")
                 output(reg=self, vm=vm, robust=False,
                        other_end=False, latex=latex)
 
@@ -1640,7 +1640,7 @@ class GMM_Error_Regimes(GM_Error_Regimes, GM_Combo_Regimes, GM_Endog_Error_Regim
                    If True, then a spatial lag of the dependent variable is included.           
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM or GNSM type.             
+                   If slx_lags>0, the specification becomes of the SLX-Error or GNSM type.             
     vm           : boolean
                    If True, include variance-covariance matrix in summary
                    results
@@ -2029,7 +2029,7 @@ def _work_endog_error(
         if add_lag != False:
             model.title = "GM SPATIAL COMBO MODEL + SLX (GNSM) - REGIME %s" % r            
         else:
-            model.title = "GM SPATIALLY WEIGHTED 2SLS + SLX (SDEM) - REGIME %s" % r
+            model.title = "GM SPATIALLY WEIGHTED 2SLS + SLX (SLX-Error) - REGIME %s" % r
     model.name_ds = name_ds
     model.name_y = "%s_%s" % (str(r), name_y)
     model.name_x = ["%s_%s" % (str(r), i) for i in name_x]

--- a/spreg/ml_error.py
+++ b/spreg/ml_error.py
@@ -313,7 +313,7 @@ class ML_Error(BaseML_Error):
                    Spatial weights sparse matrix
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.                   
+                   If slx_lags>0, the specification becomes of the SLX-Error type.                   
     method       : string
                    if 'full', brute force calculation (full matrix expressions)
                    if 'ord', Ord eigenvalue method
@@ -493,7 +493,7 @@ class ML_Error(BaseML_Error):
             x_constant = np.hstack((x_constant, lag_x))
 #            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
             name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags) # exclude constant from name_x
-            self.title += " WITH SLX (SDEM)"
+            self.title += " WITH SLX (SLX-Error)"
         self.title += " (METHOD = " + method + ")"
 
         method = method.upper()

--- a/spreg/ml_error.py
+++ b/spreg/ml_error.py
@@ -485,13 +485,14 @@ class ML_Error(BaseML_Error):
         y = USER.check_y(y, n)
         USER.check_weights(w, y, w_required=True)
         x_constant, name_x, warn = USER.check_constant(x, name_x)
+        name_x = USER.set_name_x(name_x, x_constant) # initialize in case None includes constant
         set_warn(self, warn)
-
         self.title = "ML SPATIAL ERROR"
         if slx_lags >0:
             lag_x = get_lags(w, x_constant[:, 1:], slx_lags)
             x_constant = np.hstack((x_constant, lag_x))
-            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+#            name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            name_x += USER.set_name_spatial_lags(name_x[1:], slx_lags) # exclude constant from name_x
             self.title += " WITH SLX (SDEM)"
         self.title += " (METHOD = " + method + ")"
 
@@ -501,7 +502,7 @@ class ML_Error(BaseML_Error):
         )
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
-        self.name_x = USER.set_name_x(name_x, x_constant)
+        self.name_x = name_x
         self.name_x.append("lambda")
         self.name_w = USER.set_name_w(name_w, w)
         self.aic = DIAG.akaike(reg=self)

--- a/spreg/ml_error_regimes.py
+++ b/spreg/ml_error_regimes.py
@@ -54,7 +54,7 @@ class ML_Error_Regimes(BaseML_Error, REGI.Regimes_Frame):
                    Spatial weights sparse matrix 
     slx_lags     : integer
                    Number of spatial lags of X to include in the model specification.
-                   If slx_lags>0, the specification becomes of the SDEM type.                          
+                   If slx_lags>0, the specification becomes of the SLX-Error type.                          
     method       : string
                    if 'full', brute force calculation (full matrix expressions)
                    if 'ord', Ord eigenvalue computation
@@ -378,7 +378,7 @@ class ML_Error_Regimes(BaseML_Error, REGI.Regimes_Frame):
 
             self.title = "ML SPATIAL ERROR"
             if slx_lags >0:
-                self.title += " WITH SLX (SDEM)"
+                self.title += " WITH SLX (SLX-Error)"
             self.title += " - REGIMES (METHOD = " + method + ")"
 
             self.name_x = USER.set_name_x(name_x, x, constant=True)
@@ -527,7 +527,7 @@ def _work_error(
     model.w = w_r
     model.title = "ML SPATIAL ERROR"
     if slx_lags >0:
-        model.title += " WITH SLX (SDEM)"
+        model.title += " WITH SLX (SLX-Error)"
     model.title += " - REGIME " + str(r) + " (METHOD = " + method + ")"
     model.name_ds = name_ds
     model.name_y = "%s_%s" % (str(r), name_y)

--- a/spreg/ml_error_regimes.py
+++ b/spreg/ml_error_regimes.py
@@ -83,7 +83,7 @@ class ML_Error_Regimes(BaseML_Error, REGI.Regimes_Frame):
     name_regimes : string
                    Name of regimes variable for use in output
     latex        : boolean
-                   Specifies if summary is to be printed in latex format
+                   Specifies if the table with the coefficients' results and their inference is to be printed in LaTeX format
 
     Attributes
     ----------

--- a/spreg/ml_lag.py
+++ b/spreg/ml_lag.py
@@ -596,7 +596,7 @@ class ML_Lag(BaseML_Lag):
         epsilon=0.0000001,
         spat_impacts=True,
         vm=False,
-        spat_diag=False,
+        spat_diag=True,
         name_y=None,
         name_x=None,
         name_w=None,

--- a/spreg/ml_lag_regimes.py
+++ b/spreg/ml_lag_regimes.py
@@ -11,9 +11,9 @@ from . import diagnostics as DIAG
 import multiprocessing as mp
 from .ml_lag import BaseML_Lag
 from .utils import set_warn, get_lags
-from platform import system
+from .sputils import _spmultiplier
 import pandas as pd
-from .output import output, _nonspat_top, _spat_pseudo_r2
+from .output import output, _nonspat_top, _spat_diag_out, _spat_pseudo_r2, _summary_impacts
 
 
 __all__ = ["ML_Lag_Regimes"]
@@ -64,6 +64,11 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                     If True, the spatial parameter for spatial lag is also
                     computed according to different regimes. If False (default),
                     the spatial parameter is fixed accross regimes.
+    spat_diag    : boolean
+                   If True, then compute Common Factor Hypothesis test when applicable
+    spat_impacts : boolean
+                   If True, include average direct impact (ADI), average indirect impact (AII),
+                    and average total impact (ATI) in summary results
     cores        : boolean
                    Specifies if multiprocessing is to be used
                    Default: no multiprocessing, cores = False
@@ -120,6 +125,9 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                    if 'full': brute force (full matrix computations)
                    if 'ord', Ord eigenvalue method
                    if 'LU', LU sparse matrix decomposition
+    cfh_test     : tuple
+                   Common Factor Hypothesis test; tuple contains the pair (statistic,
+                   p-value). Only when it applies (see specific documentation).
     epsilon      : float
                    tolerance criterion used in minimize_scalar function and inverse_product
     mean_y       : float
@@ -309,6 +317,8 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         slx_lags=0,
         regime_lag_sep=False,
         cores=False,
+        spat_diag=True,
+        spat_impacts=True,
         vm=False,
         name_y=None,
         name_x=None,
@@ -328,10 +338,11 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         set_warn(self, warn)
         name_x = USER.set_name_x(name_x, x_constant, constant=True)
 
-        if slx_lags >0:
+        if slx_lags > 0:
             lag_x = get_lags(w, x_constant, slx_lags)
             x_constant = np.hstack((x_constant, lag_x))
             name_x += USER.set_name_spatial_lags(name_x, slx_lags)
+            kwx = lag_x.shape[1]
 
         self.name_x_r = USER.set_name_x(name_x, x_constant) + [USER.set_name_yend_sp(name_y)]
         self.method = method
@@ -384,6 +395,8 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
                 cols2regi=cols2regi,
                 method=method,
                 epsilon=epsilon,
+                spat_diag=spat_diag,
+                spat_impacts=spat_impacts,
                 vm=vm,
                 name_y=name_y,
                 name_x=name_x,
@@ -407,23 +420,43 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
             self.name_x.append("_Global_" + USER.set_name_yend_sp(name_y))
             BaseML_Lag.__init__(self, y=y, x=x, w=w, method=method, epsilon=epsilon)
             self.kf += 1  # Adding a fixed k to account for spatial lag in Chow
-            # adding a fixed k to account for spatial lag in aic, sc
+            # adding a k to account for spatial lag in aic, sc
             self.k += 1
             self.chow = REGI.Chow(self)
             self.aic = DIAG.akaike(reg=self)
             self.schwarz = DIAG.schwarz(reg=self)
             self.regime_lag_sep = regime_lag_sep
             self.output = pd.DataFrame(self.name_x, columns=['var_names'])
+            self.output['regime'] = x_rlist + ['_Global']
             self.output['var_type'] = ['x'] * (len(self.name_x) - 1) + ['rho']
-            self.output['regime'] = x_rlist+['_Global']
             self.output['equation'] = 0
+            self.slx_lags = slx_lags
+            diag_out = None
+            if slx_lags > 0:
+                self.title = ("MAXIMUM LIKELIHOOD SPATIAL DURBIN - REGIMES"+ " (METHOD = "+ method+ ")")
+                fixed_wx = cols2regi[-(kwx+1):-1].count(False)
+                kwx = kwx - fixed_wx
+                if kwx > 0:
+                    for m in self.regimes_set:
+                        r_output = self.output[(self.output['regime'] == str(m)) & (self.output['var_type'] == 'x')]
+                        wx_index = r_output.index[-kwx:]
+                        self.output.loc[wx_index, 'var_type'] = 'wx'
+                if fixed_wx > 0:
+                    f_wx_index = self.output.index[-(fixed_wx+1):-1]
+                    self.output.loc[f_wx_index, 'var_type'] = 'wx'
+                if spat_diag and slx_lags == 1:
+                    diag_out = _spat_diag_out(self, w, 'yend', ml=True)
+            else:
+                self.title = ("MAXIMUM LIKELIHOOD SPATIAL LAG - REGIMES"+ " (METHOD = "+ method+ ")")
+            if spat_impacts and slx_lags == 0:
+                impacts = _summary_impacts(self, _spmultiplier(w, self.rho))
+                try:
+                    diag_out += impacts
+                except TypeError:
+                    diag_out = impacts
             self.other_top = _spat_pseudo_r2(self)
             self.other_top += _nonspat_top(self, ml=True)
-            if slx_lags == 0:
-                self.title = ("MAXIMUM LIKELIHOOD SPATIAL LAG - REGIMES"+ " (METHOD = "+ method+ ")")
-            else:
-                self.title = ("MAXIMUM LIKELIHOOD SPATIAL DURBIN - REGIMES"+ " (METHOD = "+ method+ ")")
-            output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
+            output(reg=self, vm=vm, robust=False, other_end=diag_out, latex=latex)
 
     def ML_Lag_Regimes_Multi(
         self,
@@ -437,6 +470,8 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
         cols2regi,
         method,
         epsilon,
+        spat_diag,
+        spat_impacts,
         vm,
         name_y,
         name_x,
@@ -558,9 +593,19 @@ class ML_Lag_Regimes(BaseML_Lag, REGI.Regimes_Frame):
             results[r].other_top = _spat_pseudo_r2(results[r])
             results[r].other_top += _nonspat_top(results[r], ml=True)
             results[r].other_mid = ""
-            self.output = pd.concat([self.output, pd.DataFrame({'var_names': results[r].name_x,
-                                                                'var_type': ['x'] * (len(results[r].name_x) - 1) + ['rho'],
-                                                                'regime': r, 'equation': r})], ignore_index=True)
+            if slx_lags > 0:
+                kx = (len(results[r].name_x) - 1) // (slx_lags + 1)
+                var_types = ['x'] * (kx + 1) + ['wx'] * kx * slx_lags + ['rho']
+            else:
+                var_types = ['x'] * (len(results[r].name_x) - 1) + ['rho']
+            results[r].output = pd.DataFrame({'var_names': results[r].name_x,
+                                              'var_type': var_types,
+                                              'regime': r, 'equation': r})
+            self.output = pd.concat([self.output, results[r].output], ignore_index=True)
+            if spat_diag and slx_lags == 1:
+                results[r].other_mid += _spat_diag_out(results[r], None, 'yend', ml=True)
+            if spat_impacts and slx_lags == 0:
+                results[r].other_mid += _summary_impacts(results[r], _spmultiplier(results[r].w, results[r].rho))
             counter += 1
         self.multi = results
         self.chow = REGI.Chow(self)
@@ -597,6 +642,7 @@ def _work(
     model.k += 1  # add 1 for proper df and aic, sc
     model.aic = DIAG.akaike(reg=model)
     model.schwarz = DIAG.schwarz(reg=model)
+    model.slx_lags = slx_lags
     return model
 
 

--- a/spreg/ml_lag_regimes.py
+++ b/spreg/ml_lag_regimes.py
@@ -643,6 +643,8 @@ def _work(
     model.aic = DIAG.akaike(reg=model)
     model.schwarz = DIAG.schwarz(reg=model)
     model.slx_lags = slx_lags
+    model.w = w_r
+    model.rho = model.betas[-1]    
     return model
 
 

--- a/spreg/ols.py
+++ b/spreg/ols.py
@@ -175,7 +175,7 @@ class OLS(BaseOLS):
     name_ds      : string
                    Name of dataset for use in output
     latex        : boolean
-                   Specifies if summary is to be printed in latex format
+                   Specifies if the table with the coefficients' results and their inference is to be printed in LaTeX format
 
     Attributes
     ----------
@@ -479,6 +479,7 @@ class OLS(BaseOLS):
         )
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_y = USER.set_name_y(name_y)
+        self.slx_lags = slx_lags
         self.title = "ORDINARY LEAST SQUARES"
         if slx_lags > 0:
             self.title += " WITH SPATIALLY LAGGED X (SLX)"

--- a/spreg/robust.py
+++ b/spreg/robust.py
@@ -1,5 +1,5 @@
-__author__ = "Luc Anselin luc.anselin@asu.edu, \
-        Pedro V. Amaral pedro.amaral@asu.edu, \
+__author__ = "Luc Anselin lanselin@gmail.com, \
+        Pedro V. Amaral pedrovma@gmail.com, \
         David C. Folch david.folch@asu.edu"
 
 import numpy as np

--- a/spreg/tests/test_error_sp_het.py
+++ b/spreg/tests/test_error_sp_het.py
@@ -5,219 +5,191 @@ from spreg import error_sp_het as HET
 from libpysal.common import RTOL
 import spreg
 
-
 class TestBaseGMErrorHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = HET.BaseGM_Error_Het(self.y, self.X, self.w.sparse, step1c=True)
-        betas = np.array([[47.99626638], [0.71048989], [-0.55876126], [0.41178776]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([27.38122697])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([32.29765975])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        predy = np.array([53.08577603])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 47.99626638], [  0.71048989], [ -0.55876126], [  0.41178776]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 27.38122697])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 32.29765975])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        predy = np.array([ 53.08577603])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [1.31767529e02, -3.58368748e00, -1.65090647e00, 0.00000000e00],
-                [-3.58368748e00, 1.35513711e-01, 3.77539055e-02, 0.00000000e00],
-                [-1.65090647e00, 3.77539055e-02, 2.61042702e-02, 0.00000000e00],
-                [0.00000000e00, 0.00000000e00, 0.00000000e00, 2.82398517e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
-        xtx = np.array(
-            [
-                [4.90000000e01, 7.04371999e02, 1.72131237e03],
-                [7.04371999e02, 1.16866734e04, 2.15575320e04],
-                [1.72131237e03, 2.15575320e04, 7.39058986e04],
-            ]
-        )
-        np.testing.assert_allclose(reg.xtx, xtx, RTOL)
-
-
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  1.31767529e+02,  -3.58368748e+00,  -1.65090647e+00,
+              0.00000000e+00],
+           [ -3.58368748e+00,   1.35513711e-01,   3.77539055e-02,
+              0.00000000e+00],
+           [ -1.65090647e+00,   3.77539055e-02,   2.61042702e-02,
+              0.00000000e+00],
+           [  0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
+              2.82398517e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
+        xtx = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03],
+           [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04],
+           [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04]])
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
+             
 class TestGMErrorHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = HET.GM_Error_Het(self.y, self.X, self.w, step1c=True)
-        betas = np.array([[47.99626638], [0.71048989], [-0.55876126], [0.41178776]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([27.38122697])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([32.29765975])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        predy = np.array([53.08577603])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 47.99626638], [  0.71048989], [ -0.55876126], [  0.41178776]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 27.38122697])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 32.29765975])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        predy = np.array([ 53.08577603])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [1.31767529e02, -3.58368748e00, -1.65090647e00, 0.00000000e00],
-                [-3.58368748e00, 1.35513711e-01, 3.77539055e-02, 0.00000000e00],
-                [-1.65090647e00, 3.77539055e-02, 2.61042702e-02, 0.00000000e00],
-                [0.00000000e00, 0.00000000e00, 0.00000000e00, 2.82398517e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  1.31767529e+02,  -3.58368748e+00,  -1.65090647e+00,
+              0.00000000e+00],
+           [ -3.58368748e+00,   1.35513711e-01,   3.77539055e-02,
+              0.00000000e+00],
+           [ -1.65090647e+00,   3.77539055e-02,   2.61042702e-02,
+              0.00000000e+00],
+           [  0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
+              2.82398517e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.34951013222581306
-        np.testing.assert_allclose(reg.pr2, pr2)
-        stde = np.array([11.47900385, 0.36812187, 0.16156816, 0.16804717])
-        np.testing.assert_allclose(reg.std_err, stde, RTOL)
-        z_stat = np.array(
-            [
-                [4.18122226e00, 2.89946274e-05],
-                [1.93003988e00, 5.36018970e-02],
-                [-3.45836247e00, 5.43469673e-04],
-                [2.45042960e00, 1.42685863e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-        xtx = np.array(
-            [
-                [4.90000000e01, 7.04371999e02, 1.72131237e03],
-                [7.04371999e02, 1.16866734e04, 2.15575320e04],
-                [1.72131237e03, 2.15575320e04, 7.39058986e04],
-            ]
-        )
-        np.testing.assert_allclose(reg.xtx, xtx, RTOL)
-
+        np.testing.assert_allclose(reg.pr2,pr2)
+        stde = np.array([ 11.47900385,   0.36812187,   0.16156816,   0.16804717])
+        np.testing.assert_allclose(reg.std_err,stde,RTOL)
+        z_stat = np.array([[  4.18122226e+00,   2.89946274e-05],
+           [  1.93003988e+00,   5.36018970e-02],
+           [ -3.45836247e+00,   5.43469673e-04],
+           [  2.45042960e+00,   1.42685863e-02]])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
+        xtx = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03],
+           [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04],
+           [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04]])
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
 
 class TestBaseGMEndogErrorHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         yd = []
         yd.append(db.by_col("CRIME"))
         self.yd = np.array(yd).T
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
-        reg = HET.BaseGM_Endog_Error_Het(
-            self.y, self.X, self.yd, self.q, self.w.sparse, step1c=True
-        )
-        betas = np.array([[55.39707924], [0.46563046], [-0.67038326], [0.41135023]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([26.51812895])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([31.46604707])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        predy = np.array([53.94887405])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        reg = HET.BaseGM_Endog_Error_Het(self.y, self.X, self.yd, self.q, self.w.sparse, step1c=True)
+        betas = np.array([[ 55.39707924], [  0.46563046], [ -0.67038326], [  0.41135023]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 26.51812895])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 31.46604707])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        predy = np.array([ 53.94887405])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        yend = np.array([15.72598])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        q = np.array([5.03])
-        np.testing.assert_allclose(reg.q[0], q, RTOL)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.z[0], z, RTOL)
-        h = np.array([1.0, 19.531, 5.03])
-        np.testing.assert_allclose(reg.h[0], h, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.   ,  19.531])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        yend = np.array([ 15.72598])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        q = np.array([ 5.03])
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
+        h = np.array([  1.   ,  19.531,   5.03 ])
+        np.testing.assert_allclose(reg.h[0],h,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [8.34637805e02, -2.16932259e01, -1.33327894e01, 1.65840848e00],
-                [-2.16932259e01, 5.97683070e-01, 3.39503523e-01, -3.90111107e-02],
-                [-1.33327894e01, 3.39503523e-01, 2.19008080e-01, -2.81929695e-02],
-                [1.65840848e00, -3.90111107e-02, -2.81929695e-02, 3.15686105e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
-        hth = np.array(
-            [
-                [49.0, 704.371999, 139.75],
-                [704.371999, 11686.67338121, 2246.12800625],
-                [139.75, 2246.12800625, 498.5851],
-            ]
-        )
-        np.testing.assert_allclose(reg.hth, hth, RTOL)
-
-
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  8.34637805e+02,  -2.16932259e+01,  -1.33327894e+01,
+                  1.65840848e+00],
+               [ -2.16932259e+01,   5.97683070e-01,   3.39503523e-01,
+                 -3.90111107e-02],
+               [ -1.33327894e+01,   3.39503523e-01,   2.19008080e-01,
+                 -2.81929695e-02],
+               [  1.65840848e+00,  -3.90111107e-02,  -2.81929695e-02,
+                  3.15686105e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
+        hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
+               [   704.371999  ,  11686.67338121,   2246.12800625],
+               [   139.75      ,   2246.12800625,    498.5851    ]])
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
+        
 class TestGMEndogErrorHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
@@ -227,364 +199,211 @@ class TestGMEndogErrorHet(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
-        reg = HET.GM_Endog_Error_Het(
-            self.y, self.X, self.yd, self.q, self.w, step1c=True
-        )
-        betas = np.array([[55.39707924], [0.46563046], [-0.67038326], [0.41135023]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([26.51812895])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([53.94887405])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        reg = HET.GM_Endog_Error_Het(self.y, self.X, self.yd, self.q, self.w, step1c=True)
+        betas = np.array([[ 55.39707924], [  0.46563046], [ -0.67038326], [  0.41135023]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 26.51812895])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 53.94887405])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        yend = np.array([15.72598])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        q = np.array([5.03])
-        np.testing.assert_allclose(reg.q[0], q, RTOL)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.z[0], z, RTOL)
-        h = np.array([1.0, 19.531, 5.03])
-        np.testing.assert_allclose(reg.h[0], h, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.   ,  19.531])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        yend = np.array([ 15.72598])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        q = np.array([ 5.03])
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
+        h = np.array([  1.   ,  19.531,   5.03 ])
+        np.testing.assert_allclose(reg.h[0],h,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [8.34637805e02, -2.16932259e01, -1.33327894e01, 1.65840848e00],
-                [-2.16932259e01, 5.97683070e-01, 3.39503523e-01, -3.90111107e-02],
-                [-1.33327894e01, 3.39503523e-01, 2.19008080e-01, -2.81929695e-02],
-                [1.65840848e00, -3.90111107e-02, -2.81929695e-02, 3.15686105e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  8.34637805e+02,  -2.16932259e+01,  -1.33327894e+01,
+                  1.65840848e+00],
+               [ -2.16932259e+01,   5.97683070e-01,   3.39503523e-01,
+                 -3.90111107e-02],
+               [ -1.33327894e+01,   3.39503523e-01,   2.19008080e-01,
+                 -2.81929695e-02],
+               [  1.65840848e+00,  -3.90111107e-02,  -2.81929695e-02,
+                  3.15686105e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.34648011338954804
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
-        std_err = np.array([28.89009873, 0.77309965, 0.46798299, 0.17767558])
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                (1.9175109006819244, 0.055173057472126787),
-                (0.60229035155742305, 0.54698088217644414),
-                (-1.4324949211864271, 0.15200223057569454),
-                (2.3151759776869496, 0.020603303355572443),
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-        hth = np.array(
-            [
-                [49.0, 704.371999, 139.75],
-                [704.371999, 11686.67338121, 2246.12800625],
-                [139.75, 2246.12800625, 498.5851],
-            ]
-        )
-        np.testing.assert_allclose(reg.hth, hth, RTOL)
-
-
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
+        std_err = np.array([ 28.89009873,  0.77309965,  0.46798299,
+            0.17767558])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([(1.9175109006819244, 0.055173057472126787), (0.60229035155742305, 0.54698088217644414), (-1.4324949211864271, 0.15200223057569454), (2.3151759776869496, 0.020603303355572443)])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
+        hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
+               [   704.371999  ,  11686.67338121,   2246.12800625],
+               [   139.75      ,   2246.12800625,    498.5851    ]])
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
+ 
 class TestBaseGMComboHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         # Only spatial lag
         yd2, q2 = spreg.utils.set_endog(self.y, self.X, self.w, None, None, 1, True)
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
-        reg = HET.BaseGM_Combo_Het(
-            self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, step1c=True
-        )
-        betas = np.array(
-            [[57.7778574], [0.73034922], [-0.59257362], [-0.2230231], [0.56636724]]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([25.65156033])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([31.87664403])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        predy = np.array([54.81544267])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
+        reg = HET.BaseGM_Combo_Het(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, step1c=True)
+        betas = np.array([[ 57.7778574 ], [  0.73034922], [ -0.59257362], [ -0.2230231 ], [  0.56636724]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 25.65156033])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 31.87664403])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        predy = np.array([ 54.81544267])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        yend = np.array([35.4585005])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        q = np.array([18.594, 24.7142675])
-        np.testing.assert_allclose(reg.q[0], q, RTOL)
-        z = np.array([1.0, 19.531, 15.72598, 35.4585005])
-        np.testing.assert_allclose(reg.z[0], z, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        yend = np.array([ 35.4585005])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        q = np.array([ 18.594    ,  24.7142675])
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
+        z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy, RTOL)
-        vm = np.array(
-            [
-                [
-                    4.86218274e02,
-                    -2.77268729e00,
-                    -1.59987770e00,
-                    -1.01969471e01,
-                    2.74302006e00,
-                ],
-                [
-                    -2.77268729e00,
-                    1.04680972e-01,
-                    2.51172238e-02,
-                    1.95136385e-03,
-                    3.70052723e-03,
-                ],
-                [
-                    -1.59987770e00,
-                    2.51172238e-02,
-                    2.15655720e-02,
-                    7.65868344e-03,
-                    -7.30173070e-03,
-                ],
-                [
-                    -1.01969471e01,
-                    1.95136385e-03,
-                    7.65868344e-03,
-                    2.78273684e-01,
-                    -6.89402590e-02,
-                ],
-                [
-                    2.74302006e00,
-                    3.70052723e-03,
-                    -7.30173070e-03,
-                    -6.89402590e-02,
-                    7.12034037e-02,
-                ],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
-        hth = np.array(
-            [
-                [
-                    4.90000000e01,
-                    7.04371999e02,
-                    1.72131237e03,
-                    7.24743592e02,
-                    1.70735413e03,
-                ],
-                [
-                    7.04371999e02,
-                    1.16866734e04,
-                    2.15575320e04,
-                    1.10925200e04,
-                    2.23848036e04,
-                ],
-                [
-                    1.72131237e03,
-                    2.15575320e04,
-                    7.39058986e04,
-                    2.34796298e04,
-                    6.70145378e04,
-                ],
-                [
-                    7.24743592e02,
-                    1.10925200e04,
-                    2.34796298e04,
-                    1.16146226e04,
-                    2.30304624e04,
-                ],
-                [
-                    1.70735413e03,
-                    2.23848036e04,
-                    6.70145378e04,
-                    2.30304624e04,
-                    6.69879858e04,
-                ],
-            ]
-        )
-        np.testing.assert_allclose(reg.hth, hth, RTOL)
-
+        np.testing.assert_allclose(reg.std_y,stdy,RTOL)
+        vm = np.array([[  4.86218274e+02,  -2.77268729e+00,  -1.59987770e+00,
+             -1.01969471e+01,   2.74302006e+00],
+           [ -2.77268729e+00,   1.04680972e-01,   2.51172238e-02,
+              1.95136385e-03,   3.70052723e-03],
+           [ -1.59987770e+00,   2.51172238e-02,   2.15655720e-02,
+              7.65868344e-03,  -7.30173070e-03],
+           [ -1.01969471e+01,   1.95136385e-03,   7.65868344e-03,
+              2.78273684e-01,  -6.89402590e-02],
+           [  2.74302006e+00,   3.70052723e-03,  -7.30173070e-03,
+             -6.89402590e-02,   7.12034037e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL*10)
+        hth = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03,
+              7.24743592e+02,   1.70735413e+03],
+           [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04,
+              1.10925200e+04,   2.23848036e+04],
+           [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04,
+              2.34796298e+04,   6.70145378e+04],
+           [  7.24743592e+02,   1.10925200e+04,   2.34796298e+04,
+              1.16146226e+04,   2.30304624e+04],
+           [  1.70735413e+03,   2.23848036e+04,   6.70145378e+04,
+              2.30304624e+04,   6.69879858e+04]])
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
 class TestGMComboHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         # Only spatial lag
         reg = HET.GM_Combo_Het(self.y, self.X, w=self.w, step1c=True)
-        betas = np.array(
-            [[57.7778574], [0.73034922], [-0.59257362], [-0.2230231], [0.56636724]]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([25.65156033])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([31.87664403])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        ep = np.array([28.30648145])
-        np.testing.assert_allclose(reg.e_pred[0], ep, RTOL)
-        pe = np.array([52.16052155])
-        np.testing.assert_allclose(reg.predy_e[0], pe, RTOL)
-        predy = np.array([54.81544267])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 57.7778574 ], [  0.73034922], [ -0.59257362], [ -0.2230231 ], [  0.56636724]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 25.65156033])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 31.87664403])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        ep = np.array([ 28.30648145])
+        np.testing.assert_allclose(reg.e_pred[0],ep,RTOL)
+        pe = np.array([ 52.16052155])
+        np.testing.assert_allclose(reg.predy_e[0],pe,RTOL)
+        predy = np.array([ 54.81544267])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0], x, RTOL)
-        yend = np.array([35.4585005])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        q = np.array([18.594, 24.7142675])
-        np.testing.assert_allclose(reg.q[0], q, RTOL)
-        z = np.array([1.0, 19.531, 15.72598, 35.4585005])
-        np.testing.assert_allclose(reg.z[0], z, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        yend = np.array([ 35.4585005])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        q = np.array([ 18.594    ,  24.7142675])
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
+        z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [
-                    4.86218274e02,
-                    -2.77268729e00,
-                    -1.59987770e00,
-                    -1.01969471e01,
-                    2.74302006e00,
-                ],
-                [
-                    -2.77268729e00,
-                    1.04680972e-01,
-                    2.51172238e-02,
-                    1.95136385e-03,
-                    3.70052723e-03,
-                ],
-                [
-                    -1.59987770e00,
-                    2.51172238e-02,
-                    2.15655720e-02,
-                    7.65868344e-03,
-                    -7.30173070e-03,
-                ],
-                [
-                    -1.01969471e01,
-                    1.95136385e-03,
-                    7.65868344e-03,
-                    2.78273684e-01,
-                    -6.89402590e-02,
-                ],
-                [
-                    2.74302006e00,
-                    3.70052723e-03,
-                    -7.30173070e-03,
-                    -6.89402590e-02,
-                    7.12034037e-02,
-                ],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  4.86218274e+02,  -2.77268729e+00,  -1.59987770e+00,
+             -1.01969471e+01,   2.74302006e+00],
+           [ -2.77268729e+00,   1.04680972e-01,   2.51172238e-02,
+              1.95136385e-03,   3.70052723e-03],
+           [ -1.59987770e+00,   2.51172238e-02,   2.15655720e-02,
+              7.65868344e-03,  -7.30173070e-03],
+           [ -1.01969471e+01,   1.95136385e-03,   7.65868344e-03,
+              2.78273684e-01,  -6.89402590e-02],
+           [  2.74302006e+00,   3.70052723e-03,  -7.30173070e-03,
+             -6.89402590e-02,   7.12034037e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL*10)
         pr2 = 0.3001582877472412
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.35613102283621967
-        np.testing.assert_allclose(reg.pr2_e, pr2_e, RTOL)
-        std_err = np.array(
-            [22.05035768, 0.32354439, 0.14685221, 0.52751653, 0.26683966]
-        )
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                (2.6202684885795335, 0.00878605635338265),
-                (2.2573385444145524, 0.023986928627746887),
-                (-4.0351698589183433, 5.456281036278686e-05),
-                (-0.42277935292121521, 0.67245625315942159),
-                (2.1225002455741895, 0.033795752094112265),
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-        hth = np.array(
-            [
-                [
-                    4.90000000e01,
-                    7.04371999e02,
-                    1.72131237e03,
-                    7.24743592e02,
-                    1.70735413e03,
-                ],
-                [
-                    7.04371999e02,
-                    1.16866734e04,
-                    2.15575320e04,
-                    1.10925200e04,
-                    2.23848036e04,
-                ],
-                [
-                    1.72131237e03,
-                    2.15575320e04,
-                    7.39058986e04,
-                    2.34796298e04,
-                    6.70145378e04,
-                ],
-                [
-                    7.24743592e02,
-                    1.10925200e04,
-                    2.34796298e04,
-                    1.16146226e04,
-                    2.30304624e04,
-                ],
-                [
-                    1.70735413e03,
-                    2.23848036e04,
-                    6.70145378e04,
-                    2.30304624e04,
-                    6.69879858e04,
-                ],
-            ]
-        )
-        np.testing.assert_allclose(reg.hth, hth, RTOL)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
+        std_err = np.array([ 22.05035768,  0.32354439,  0.14685221,  0.52751653,  0.26683966])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([(2.6202684885795335, 0.00878605635338265), (2.2573385444145524, 0.023986928627746887), (-4.0351698589183433, 5.456281036278686e-05), (-0.42277935292121521, 0.67245625315942159), (2.1225002455741895, 0.033795752094112265)])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
+        hth = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03,
+              7.24743592e+02,   1.70735413e+03],
+           [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04,
+              1.10925200e+04,   2.23848036e+04],
+           [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04,
+              2.34796298e+04,   6.70145378e+04],
+           [  7.24743592e+02,   1.10925200e+04,   2.34796298e+04,
+              1.16146226e+04,   2.30304624e+04],
+           [  1.70735413e+03,   2.23848036e+04,   6.70145378e+04,
+              2.30304624e+04,   6.69879858e+04]])
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/spreg/tests/test_error_sp_het_regimes.py
+++ b/spreg/tests/test_error_sp_het_regimes.py
@@ -5,13 +5,12 @@ from spreg import error_sp_het_regimes as SP
 from spreg.error_sp_het import GM_Error_Het, GM_Endog_Error_Het, GM_Combo_Het
 from libpysal.common import RTOL
 
-
 class TestGM_Error_Het_Regimes(unittest.TestCase):
     def setUp(self):
-        # Columbus:
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        #Columbus:
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("CRIME"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("HOVAL"))
         X.append(db.by_col("INC"))
@@ -25,474 +24,284 @@ class TestGM_Error_Het_Regimes(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Queen.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-        self.r_var = "NSA"
+        self.w = libpysal.weights.Queen.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
+        self.r_var = 'NSA'
         self.regimes = db.by_col(self.r_var)
-        # Artficial:
+        #Artficial:
         n = 256
-        self.n2 = n / 2
-        self.x_a1 = np.random.uniform(-10, 10, (n, 1))
-        self.x_a2 = np.random.uniform(1, 5, (n, 1))
-        self.q_a = self.x_a2 + np.random.normal(0, 1, (n, 1))
-        self.x_a = np.hstack((self.x_a1, self.x_a2))
-        self.y_a = np.dot(
-            np.hstack((np.ones((n, 1)), self.x_a)), np.array([[1], [0.5], [2]])
-        ) + np.random.normal(0, 1, (n, 1))
+        self.n2 = n/2
+        self.x_a1 = np.random.uniform(-10,10,(n,1))
+        self.x_a2 = np.random.uniform(1,5,(n,1))
+        self.q_a = self.x_a2 + np.random.normal(0,1,(n,1))
+        self.x_a = np.hstack((self.x_a1,self.x_a2))
+        self.y_a = np.dot(np.hstack((np.ones((n,1)),self.x_a)),np.array([[1],[0.5],[2]])) + np.random.normal(0,1,(n,1))
         latt = int(np.sqrt(n))
-        self.w_a = libpysal.weights.util.lat2W(latt, latt)
-        self.w_a.transform = "r"
-        self.regi_a = [0] * (n // 2) + [1] * (n // 2)
-        self.w_a1 = libpysal.weights.util.lat2W(latt // 2, latt)
-        self.w_a1.transform = "r"
-
+        self.w_a = libpysal.weights.util.lat2W(latt,latt)
+        self.w_a.transform='r'
+        self.regi_a = [0]*(n//2) + [1]*(n//2)
+        self.w_a1 = libpysal.weights.util.lat2W(latt//2,latt)
+        self.w_a1.transform='r'
+        
     def test_model(self):
         reg = SP.GM_Error_Het_Regimes(self.y, self.X, self.regimes, self.w)
-        betas = np.array(
-            [
-                [62.95986466],
-                [-0.15660795],
-                [-1.49054832],
-                [60.98577615],
-                [-0.3358993],
-                [-0.82129289],
-                [0.54662719],
-            ]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
+        betas = np.array([[ 62.95986466],
+       [ -0.15660795],
+       [ -1.49054832],
+       [ 60.98577615],
+       [ -0.3358993 ],
+       [ -0.82129289],
+       [  0.54662719]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([-2.19031456])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([17.91629456])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 17.91629456])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 6
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([15.72598])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([[0.0, 0.0, 0.0, 1.0, 80.467003, 19.531]])
-        np.testing.assert_allclose(reg.x[0].toarray(), x, RTOL)
-        e = np.array([2.77847355])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL)
+        y = np.array([ 15.72598])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([[  0.      ,   0.      ,   0.      ,   1.      ,  80.467003,  19.531   ]])
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
+        e = np.array([ 2.77847355])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         my = 35.128823897959187
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my, RTOL)
         sy = 16.732092091229699
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                3.86154100e01,
-                -2.51553730e-01,
-                -8.20138673e-01,
-                1.71714184e00,
-                -1.94929113e-02,
-                1.23118051e-01,
-                0.00000000e00,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy, RTOL)
+        vm = np.array([  3.86154100e+01,  -2.51553730e-01,  -8.20138673e-01,
+         1.71714184e+00,  -1.94929113e-02,   1.23118051e-01,
+         0.00000000e+00])
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL*10)
         pr2 = 0.5515791216043385
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
-        std_err = np.array(
-            [
-                6.21412987,
-                0.15340022,
-                0.44060473,
-                7.6032169,
-                0.19353719,
-                0.73621596,
-                0.13968272,
-            ]
-        )
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        chow_r = np.array(
-            [
-                [0.04190799, 0.83779526],
-                [0.5736724, 0.44880328],
-                [0.62498575, 0.42920056],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_r, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2, RTOL)
+        std_err = np.array([ 6.21412987,  0.15340022,  0.44060473,  7.6032169 ,  0.19353719,
+        0.73621596,  0.13968272])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        chow_r = np.array([[ 0.04190799,  0.83779526],
+       [ 0.5736724 ,  0.44880328],
+       [ 0.62498575,  0.42920056]])
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.72341901308525713
-        np.testing.assert_allclose(reg.chow.joint[0], chow_j, RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
 
     def test_model_regi_error(self):
-        # Columbus:
-        reg = SP.GM_Error_Het_Regimes(
-            self.y, self.X, self.regimes, self.w, regime_err_sep=True
-        )
-        betas = np.array(
-            [
-                [60.74090229],
-                [-0.17492294],
-                [-1.33383387],
-                [0.68303064],
-                [66.30374279],
-                [-0.31841139],
-                [-1.27502813],
-                [0.11515312],
-            ]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        vm = np.array([44.9411672, -0.34343354, -0.39946055, 0.0, 0.0, 0.0, 0.0, 0.0])
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
+        #Columbus:
+        reg = SP.GM_Error_Het_Regimes(self.y, self.X, self.regimes, self.w, regime_err_sep=True)
+        betas = np.array([[ 60.74090229],
+       [ -0.17492294],
+       [ -1.33383387],
+       [  0.68303064],
+       [ 66.30374279],
+       [ -0.31841139],
+       [ -1.27502813],
+       [  0.11515312]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        vm = np.array([ 44.9411672 ,  -0.34343354,  -0.39946055,   0.        ,
+         0.        ,   0.        ,   0.        ,   0.        ])
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([-0.05357818])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([15.77955818])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
-        e = np.array([0.70542044])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        chow_r = np.array(
-            [
-                [3.11061225e-01, 5.77029704e-01],
-                [3.39747489e-01, 5.59975012e-01],
-                [3.86371771e-03, 9.50436364e-01],
-                [4.02884201e00, 4.47286322e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_r, RTOL)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 15.77955818])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
+        e = np.array([ 0.70542044])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        chow_r = np.array([[  3.11061225e-01,   5.77029704e-01],
+       [  3.39747489e-01,   5.59975012e-01],
+       [  3.86371771e-03,   9.50436364e-01],
+       [  4.02884201e+00,   4.47286322e-02]])
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 4.7467070503995412
-        np.testing.assert_allclose(reg.chow.joint[0], chow_j, RTOL)
-        # Artficial:
-        model = SP.GM_Error_Het_Regimes(
-            self.y_a, self.x_a, self.regi_a, w=self.w_a, regime_err_sep=True
-        )
-        model1 = GM_Error_Het(
-            self.y_a[0 : int(self.n2)].reshape(int(self.n2), 1),
-            self.x_a[0 : int(self.n2)],
-            w=self.w_a1,
-        )
-        model2 = GM_Error_Het(
-            self.y_a[int(self.n2) :].reshape(int(self.n2), 1),
-            self.x_a[int(self.n2) :],
-            w=self.w_a1,
-        )
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
+        #Artficial:
+        model = SP.GM_Error_Het_Regimes(self.y_a, self.x_a, self.regi_a, w=self.w_a, regime_err_sep=True)
+        model1 = GM_Error_Het(self.y_a[0:int(self.n2)].reshape(int(self.n2),1), self.x_a[0:int(self.n2)], w=self.w_a1)
+        model2 = GM_Error_Het(self.y_a[int(self.n2):].reshape(int(self.n2),1), self.x_a[int(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_allclose(model.betas, tbetas, RTOL)
-        vm = np.hstack((model1.vm.diagonal(), model2.vm.diagonal()))
+        np.testing.assert_allclose(model.betas,tbetas, RTOL)
+        vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
         np.testing.assert_allclose(model.vm.diagonal(), vm, RTOL)
 
     def test_model_endog(self):
-        reg = SP.GM_Endog_Error_Het_Regimes(
-            self.y, self.X2, self.yd, self.q, self.regimes, self.w
-        )
-        betas = np.array(
-            [
-                [77.26679984],
-                [4.45992905],
-                [78.59534391],
-                [0.41432319],
-                [-3.20196286],
-                [-1.13672283],
-                [0.2174965],
-            ]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([20.50716917])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e = np.array([25.13517175])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
+        reg = SP.GM_Endog_Error_Het_Regimes(self.y, self.X2, self.yd, self.q, self.regimes, self.w)
+        betas = np.array([[ 77.26679984],
+       [  4.45992905],
+       [ 78.59534391],
+       [  0.41432319],
+       [ -3.20196286],
+       [ -1.13672283],
+       [  0.2174965 ]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 20.50716917])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        e = np.array([ 25.13517175])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([-4.78118917])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n, RTOL)
         k = 6
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([15.72598])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([[0.0, 0.0, 1.0, 19.531]])
-        np.testing.assert_allclose(reg.x[0].toarray(), x, RTOL)
-        yend = np.array([[0.0, 80.467003]])
-        np.testing.assert_allclose(reg.yend[0].toarray(), yend, RTOL)
-        z = np.array([[0.0, 0.0, 1.0, 19.531, 0.0, 80.467003]])
-        np.testing.assert_allclose(reg.z[0].toarray(), z, RTOL)
+        np.testing.assert_allclose(reg.k,k, RTOL)
+        y = np.array([ 15.72598])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
+        yend = np.array([[  0.      ,  80.467003]])
+        np.testing.assert_allclose(reg.yend[0].toarray(),yend,RTOL)
+        z = np.array([[  0.      ,   0.      ,   1.      ,  19.531   ,   0.      ,
+         80.467003]])
+        np.testing.assert_allclose(reg.z[0].toarray(),z,RTOL)
         my = 35.128823897959187
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my, RTOL)
         sy = 16.732092091229699
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                509.66122149,
-                150.5845341,
-                9.64413821,
-                5.54782831,
-                -80.95846045,
-                -2.25308524,
-                -3.2045214,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy, RTOL)
+        vm = np.array([ 509.66122149,  150.5845341 ,    9.64413821,    5.54782831,
+        -80.95846045,   -2.25308524,   -3.2045214 ])
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         pr2 = 0.19776512679331681
-        np.testing.assert_allclose(reg.pr2, pr2)
-        std_err = np.array(
-            [
-                22.57567765,
-                11.34616946,
-                17.43881791,
-                1.30953812,
-                5.4830829,
-                0.74634612,
-                0.29973079,
-            ]
-        )
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        chow_r = np.array(
-            [[0.0022216, 0.96240654], [0.13127347, 0.7171153], [0.14367307, 0.70465645]]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_r, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2)
+        std_err = np.array([ 22.57567765,  11.34616946,  17.43881791,   1.30953812,
+         5.4830829 ,   0.74634612,   0.29973079])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        chow_r = np.array([[ 0.0022216 ,  0.96240654],
+       [ 0.13127347,  0.7171153 ],
+       [ 0.14367307,  0.70465645]])
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.2329971019087163
-        np.testing.assert_allclose(reg.chow.joint[0], chow_j, RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
 
     def test_model_endog_regi_error(self):
-        # Columbus:
-        reg = SP.GM_Endog_Error_Het_Regimes(
-            self.y, self.X2, self.yd, self.q, self.regimes, self.w, regime_err_sep=True
-        )
-        betas = np.array(
-            [
-                [7.92747424e01],
-                [5.78086230e00],
-                [-3.83173581e00],
-                [2.23210962e-01],
-                [8.26255251e01],
-                [5.48294187e-01],
-                [-1.28432891e00],
-                [3.57661629e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        vm = np.array(
-            [
-                7.55988579e02,
-                2.53659722e02,
-                -1.34288316e02,
-                -2.66141766e-01,
-                0.00000000e00,
-                0.00000000e00,
-                0.00000000e00,
-                0.00000000e00,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        u = np.array([25.73781918])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([-10.01183918])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
-        e = np.array([26.5449135])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        chow_r = np.array(
-            [
-                [0.00998573, 0.92040097],
-                [0.12660165, 0.72198192],
-                [0.12737281, 0.72117171],
-                [0.43507956, 0.50950696],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_r, RTOL)
-        chow_j = 1.3756768204399892
-        np.testing.assert_allclose(reg.chow.joint[0], chow_j, RTOL)
-        # Artficial:
-        model = SP.GM_Endog_Error_Het_Regimes(
-            self.y_a,
-            self.x_a1,
-            yend=self.x_a2,
-            q=self.q_a,
-            regimes=self.regi_a,
-            w=self.w_a,
-            regime_err_sep=True,
-        )
-        model1 = GM_Endog_Error_Het(
-            self.y_a[0 : int(self.n2)].reshape(int(self.n2), 1),
-            self.x_a1[0 : int(self.n2)],
-            yend=self.x_a2[0 : int(self.n2)],
-            q=self.q_a[0 : int(self.n2)],
-            w=self.w_a1,
-        )
-        model2 = GM_Endog_Error_Het(
-            self.y_a[int(self.n2) :].reshape(int(self.n2), 1),
-            self.x_a1[int(self.n2) :],
-            yend=self.x_a2[int(self.n2) :],
-            q=self.q_a[int(self.n2) :],
-            w=self.w_a1,
-        )
+        #Columbus:
+        reg = SP.GM_Endog_Error_Het_Regimes(self.y, self.X2, self.yd, self.q, self.regimes, self.w, regime_err_sep=True)
+        betas = np.array([[70.45311952],
+                [ 4.3685181 ],
+                [-0.9       ],
+                [ 0.89261347],
+                [78.43187245],
+                [ 0.95437565],
+                [-0.9       ],
+                [ 0.73629337]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        vm = np.array([ 1.210078e+03,  1.559293e+02, -7.540641e+01,  1.141481e+00,
+        0.000000e+00,  0.000000e+00,  0.000000e+00,  0.000000e+00])
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
+        u = np.array([-8.925501])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([24.651481])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
+        e = np.array([20.195355])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        chow_r = np.array([[0.041109, 0.839328],
+                [0.102719, 0.748591],
+                [0.      , 1.      ],
+                [0.311214, 0.576936]])
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
+        chow_j = 2.621305
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
+        #Artficial:
+        model = SP.GM_Endog_Error_Het_Regimes(self.y_a, self.x_a1, yend=self.x_a2, q=self.q_a, regimes=self.regi_a, w=self.w_a, regime_err_sep=True)
+        model1 = GM_Endog_Error_Het(self.y_a[0:int(self.n2)].reshape(int(self.n2),1), self.x_a1[0:int(self.n2)], yend=self.x_a2[0:int(self.n2)], q=self.q_a[0:int(self.n2)], w=self.w_a1)
+        model2 = GM_Endog_Error_Het(self.y_a[int(self.n2):].reshape(int(self.n2),1), self.x_a1[int(self.n2):], yend=self.x_a2[int(self.n2):], q=self.q_a[int(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_allclose(model.betas, tbetas, RTOL)
-        vm = np.hstack((model1.vm.diagonal(), model2.vm.diagonal()))
+        np.testing.assert_allclose(model.betas,tbetas, RTOL)
+        vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
         np.testing.assert_allclose(model.vm.diagonal(), vm, RTOL)
 
     def test_model_combo(self):
-        reg = SP.GM_Combo_Het_Regimes(
-            self.y, self.X2, self.regimes, self.yd, self.q, w=self.w
-        )
-        betas = np.array(
-            [
-                [3.69372678e01],
-                [-8.29474998e-01],
-                [3.08667517e01],
-                [-7.23753444e-01],
-                [-3.01900940e-01],
-                [-2.21328949e-01],
-                [6.41902155e-01],
-                [-2.45714919e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([0.94039246])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        e_filtered = np.array([0.8737864])
-        np.testing.assert_allclose(reg.e_filtered[0], e_filtered, RTOL)
-        predy_e = np.array([18.68732105])
-        np.testing.assert_allclose(reg.predy_e[0], predy_e, RTOL)
-        predy = np.array([14.78558754])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        reg = SP.GM_Combo_Het_Regimes(self.y, self.X2, self.regimes, self.yd, self.q, w=self.w)
+        betas = np.array([[  3.69372678e+01],
+       [ -8.29474998e-01],
+       [  3.08667517e+01],
+       [ -7.23753444e-01],
+       [ -3.01900940e-01],
+       [ -2.21328949e-01],
+       [  6.41902155e-01],
+       [ -2.45714919e-02]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 0.94039246])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        e_filtered = np.array([ 0.8737864])
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
+        predy_e = np.array([ 18.68732105])
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,RTOL)
+        predy = np.array([ 14.78558754])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n, RTOL)
+        np.testing.assert_allclose(reg.n,n, RTOL)
         k = 7
-        np.testing.assert_allclose(reg.k, k, RTOL)
-        y = np.array([15.72598])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([[0.0, 0.0, 1.0, 19.531]])
-        np.testing.assert_allclose(reg.x[0].toarray(), x, RTOL)
-        yend = np.array([[0.0, 80.467003, 24.7142675]])
-        np.testing.assert_allclose(reg.yend[0].toarray(), yend, RTOL)
-        z = np.array([[0.0, 0.0, 1.0, 19.531, 0.0, 80.467003, 24.7142675]])
-        np.testing.assert_allclose(reg.z[0].toarray(), z, RTOL)
+        np.testing.assert_allclose(reg.k,k, RTOL)
+        y = np.array([ 15.72598])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
+        yend = np.array([[  0.       ,  80.467003 ,  24.7142675]])
+        np.testing.assert_allclose(reg.yend[0].toarray(),yend,RTOL)
+        z = np.array([[  0.       ,   0.       ,   1.       ,  19.531    ,   0.       ,
+         80.467003 ,  24.7142675]])
+        np.testing.assert_allclose(reg.z[0].toarray(),z,RTOL)
         my = 35.128823897959187
-        np.testing.assert_allclose(reg.mean_y, my, RTOL)
+        np.testing.assert_allclose(reg.mean_y,my, RTOL)
         sy = 16.732092091229699
-        np.testing.assert_allclose(reg.std_y, sy, RTOL)
-        vm = np.array(
-            [
-                71.26851365,
-                -0.58278032,
-                50.53169815,
-                -0.74561147,
-                -0.79510274,
-                -0.10823496,
-                -0.98141395,
-                1.16575965,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,sy, RTOL)
+        vm = np.array([ 71.26851365,  -0.58278032,  50.53169815,  -0.74561147,
+        -0.79510274,  -0.10823496,  -0.98141395,   1.16575965])
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         pr2 = 0.6504148883602958
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.527136896994038
-        np.testing.assert_allclose(reg.pr2_e, pr2_e, RTOL)
-        std_err = np.array(
-            [
-                8.44206809,
-                0.72363219,
-                9.85790968,
-                0.77218082,
-                0.34084146,
-                0.21752916,
-                0.14371614,
-                0.39226478,
-            ]
-        )
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        chow_r = np.array(
-            [
-                [0.54688708, 0.45959243],
-                [0.01035136, 0.91896175],
-                [0.03981108, 0.84185042],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_r, RTOL)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
+        std_err = np.array([ 8.44206809,  0.72363219,  9.85790968,  0.77218082,  0.34084146,
+        0.21752916,  0.14371614,  0.39226478])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        chow_r = np.array([[ 0.54688708,  0.45959243],
+       [ 0.01035136,  0.91896175],
+       [ 0.03981108,  0.84185042]])
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.78070369988354349
-        np.testing.assert_allclose(reg.chow.joint[0], chow_j, RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model_combo_regi_error(self):
-        # Columbus:
-        reg = SP.GM_Combo_Het_Regimes(
-            self.y,
-            self.X2,
-            self.regimes,
-            self.yd,
-            self.q,
-            w=self.w,
-            regime_lag_sep=True,
-            regime_err_sep=True,
-        )
-        betas = np.array(
-            [
-                [42.01151458],
-                [-0.13917151],
-                [-0.65300184],
-                [0.54737064],
-                [0.2629229],
-                [34.21569751],
-                [-0.15236089],
-                [-0.49175217],
-                [0.65733173],
-                [-0.07713581],
-            ]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        vm = np.array(
-            [
-                77.49519689,
-                0.57226879,
-                -1.18856422,
-                -1.28088712,
-                0.866752,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            ]
-        )
-        np.testing.assert_allclose(reg.vm[0], vm, RTOL)
-        u = np.array([7.81039418])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([7.91558582])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
-        e = np.array([7.22996911])
-        np.testing.assert_allclose(reg.e_filtered[0], e, RTOL)
-        chow_r = np.array(
-            [
-                [1.90869079e-01, 6.62194273e-01],
-                [4.56118982e-05, 9.94611401e-01],
-                [3.12104263e-02, 8.59771748e-01],
-                [1.56368204e-01, 6.92522476e-01],
-                [7.52928732e-01, 3.85550558e-01],
-            ]
-        )
-        np.testing.assert_allclose(reg.chow.regi, chow_r, RTOL)
+        #Columbus:
+        reg = SP.GM_Combo_Het_Regimes(self.y, self.X2, self.regimes, self.yd, self.q, w=self.w, regime_lag_sep=True, regime_err_sep=True)
+        betas = np.array([[ 42.01151458],
+       [ -0.13917151],
+       [ -0.65300184],
+       [  0.54737064],
+       [  0.2629229 ],
+       [ 34.21569751],
+       [ -0.15236089],
+       [ -0.49175217],
+       [  0.65733173],
+       [ -0.07713581]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        vm = np.array([ 77.49519689,   0.57226879,  -1.18856422,  -1.28088712,
+         0.866752  ,   0.        ,   0.        ,   0.        ,
+         0.        ,   0.        ])
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
+        u = np.array([ 7.81039418])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 7.91558582])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
+        e = np.array([ 7.22996911])
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        chow_r = np.array([[  1.90869079e-01,   6.62194273e-01],
+       [  4.56118982e-05,   9.94611401e-01],
+       [  3.12104263e-02,   8.59771748e-01],
+       [  1.56368204e-01,   6.92522476e-01],
+       [  7.52928732e-01,   3.85550558e-01]])
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.1316136604755913
-        np.testing.assert_allclose(reg.chow.joint[0], chow_j, RTOL)
-        # Artficial:
-        model = SP.GM_Combo_Het_Regimes(
-            self.y_a,
-            self.x_a1,
-            yend=self.x_a2,
-            q=self.q_a,
-            regimes=self.regi_a,
-            w=self.w_a,
-            regime_err_sep=True,
-            regime_lag_sep=True,
-        )
-        model1 = GM_Combo_Het(
-            self.y_a[0 : int(self.n2)].reshape(int(self.n2), 1),
-            self.x_a1[0 : int(self.n2)],
-            yend=self.x_a2[0 : int(self.n2)],
-            q=self.q_a[0 : int(self.n2)],
-            w=self.w_a1,
-        )
-        model2 = GM_Combo_Het(
-            self.y_a[int(self.n2) :].reshape(int(self.n2), 1),
-            self.x_a1[int(self.n2) :],
-            yend=self.x_a2[int(self.n2) :],
-            q=self.q_a[int(self.n2) :],
-            w=self.w_a1,
-        )
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
+        #Artficial:
+        model = SP.GM_Combo_Het_Regimes(self.y_a, self.x_a1, yend=self.x_a2, q=self.q_a, regimes=self.regi_a, w=self.w_a, regime_err_sep=True, regime_lag_sep=True)
+        model1 = GM_Combo_Het(self.y_a[0:int(self.n2)].reshape(int(self.n2),1), self.x_a1[0:int(self.n2)], yend=self.x_a2[0:int(self.n2)], q=self.q_a[0:int(self.n2)], w=self.w_a1)
+        model2 = GM_Combo_Het(self.y_a[int(self.n2):].reshape(int(self.n2),1), self.x_a1[int(self.n2):], yend=self.x_a2[int(self.n2):], q=self.q_a[int(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_allclose(model.betas, tbetas, RTOL)
-        vm = np.hstack((model1.vm.diagonal(), model2.vm.diagonal()))
-        # was this supposed to get tested?
+        np.testing.assert_allclose(model.betas,tbetas,RTOL)
+        vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
+        #was this supposed to get tested?
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/spreg/tests/test_error_sp_het_sparse.py
+++ b/spreg/tests/test_error_sp_het_sparse.py
@@ -6,150 +6,131 @@ from spreg import error_sp_het as HET
 from libpysal.common import RTOL
 import spreg
 
-
 class TestBaseGMErrorHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = HET.BaseGM_Error_Het(self.y, self.X, self.w.sparse, step1c=True)
-        betas = np.array([[47.99626638], [0.71048989], [-0.55876126], [0.41178776]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([27.38122697])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([32.29765975])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        predy = np.array([53.08577603])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 47.99626638], [  0.71048989], [ -0.55876126], [  0.41178776]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 27.38122697])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 32.29765975])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        predy = np.array([ 53.08577603])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0].toarray()[0], x, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [1.31767529e02, -3.58368748e00, -1.65090647e00, 0.00000000e00],
-                [-3.58368748e00, 1.35513711e-01, 3.77539055e-02, 0.00000000e00],
-                [-1.65090647e00, 3.77539055e-02, 2.61042702e-02, 0.00000000e00],
-                [0.00000000e00, 0.00000000e00, 0.00000000e00, 2.82398517e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
-        xtx = np.array(
-            [
-                [4.90000000e01, 7.04371999e02, 1.72131237e03],
-                [7.04371999e02, 1.16866734e04, 2.15575320e04],
-                [1.72131237e03, 2.15575320e04, 7.39058986e04],
-            ]
-        )
-        np.testing.assert_allclose(reg.xtx, xtx, RTOL)
-
-
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  1.31767529e+02,  -3.58368748e+00,  -1.65090647e+00,
+              0.00000000e+00],
+           [ -3.58368748e+00,   1.35513711e-01,   3.77539055e-02,
+              0.00000000e+00],
+           [ -1.65090647e+00,   3.77539055e-02,   2.61042702e-02,
+              0.00000000e+00],
+           [  0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
+              2.82398517e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
+        xtx = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03],
+           [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04],
+           [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04]])
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
+             
 class TestGMErrorHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         reg = HET.GM_Error_Het(self.y, self.X, self.w, step1c=True)
-        betas = np.array([[47.99626638], [0.71048989], [-0.55876126], [0.41178776]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([27.38122697])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([32.29765975])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        predy = np.array([53.08577603])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 47.99626638], [  0.71048989], [ -0.55876126], [  0.41178776]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 27.38122697])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 32.29765975])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        predy = np.array([ 53.08577603])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0].toarray()[0], x, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [1.31767529e02, -3.58368748e00, -1.65090647e00, 0.00000000e00],
-                [-3.58368748e00, 1.35513711e-01, 3.77539055e-02, 0.00000000e00],
-                [-1.65090647e00, 3.77539055e-02, 2.61042702e-02, 0.00000000e00],
-                [0.00000000e00, 0.00000000e00, 0.00000000e00, 2.82398517e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  1.31767529e+02,  -3.58368748e+00,  -1.65090647e+00,
+              0.00000000e+00],
+           [ -3.58368748e+00,   1.35513711e-01,   3.77539055e-02,
+              0.00000000e+00],
+           [ -1.65090647e+00,   3.77539055e-02,   2.61042702e-02,
+              0.00000000e+00],
+           [  0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
+              2.82398517e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.34951013222581306
-        np.testing.assert_allclose(reg.pr2, pr2)
-        stde = np.array([11.47900385, 0.36812187, 0.16156816, 0.16804717])
-        np.testing.assert_allclose(reg.std_err, stde, RTOL)
-        z_stat = np.array(
-            [
-                [4.18122226e00, 2.89946274e-05],
-                [1.93003988e00, 5.36018970e-02],
-                [-3.45836247e00, 5.43469673e-04],
-                [2.45042960e00, 1.42685863e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-        xtx = np.array(
-            [
-                [4.90000000e01, 7.04371999e02, 1.72131237e03],
-                [7.04371999e02, 1.16866734e04, 2.15575320e04],
-                [1.72131237e03, 2.15575320e04, 7.39058986e04],
-            ]
-        )
-        np.testing.assert_allclose(reg.xtx, xtx, RTOL)
-
+        np.testing.assert_allclose(reg.pr2,pr2)
+        stde = np.array([ 11.47900385,   0.36812187,   0.16156816,   0.16804717])
+        np.testing.assert_allclose(reg.std_err,stde,RTOL)
+        z_stat = np.array([[  4.18122226e+00,   2.89946274e-05],
+           [  1.93003988e+00,   5.36018970e-02],
+           [ -3.45836247e+00,   5.43469673e-04],
+           [  2.45042960e+00,   1.42685863e-02]])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
+        xtx = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03],
+           [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04],
+           [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04]])
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
 
 class TestBaseGMEndogErrorHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
         yd = []
         yd.append(db.by_col("CRIME"))
@@ -157,71 +138,62 @@ class TestBaseGMEndogErrorHet(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
-        reg = HET.BaseGM_Endog_Error_Het(
-            self.y, self.X, self.yd, self.q, self.w.sparse, step1c=True
-        )
-        betas = np.array([[55.39707924], [0.46563046], [-0.67038326], [0.41135023]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([26.51812895])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([31.46604707])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        predy = np.array([53.94887405])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        reg = HET.BaseGM_Endog_Error_Het(self.y, self.X, self.yd, self.q, self.w.sparse, step1c=True)
+        betas = np.array([[ 55.39707924], [  0.46563046], [ -0.67038326], [  0.41135023]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 26.51812895])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 31.46604707])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        predy = np.array([ 53.94887405])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_allclose(reg.x[0].toarray()[0], x, RTOL)
-        yend = np.array([15.72598])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        q = np.array([5.03])
-        np.testing.assert_allclose(reg.q[0], q, RTOL)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.z[0].toarray()[0], z, RTOL)
-        h = np.array([1.0, 19.531, 5.03])
-        np.testing.assert_allclose(reg.h[0].toarray()[0], h, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.   ,  19.531])
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
+        yend = np.array([ 15.72598])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        q = np.array([ 5.03])
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.z[0].toarray()[0],z,RTOL)
+        h = np.array([  1.   ,  19.531,   5.03 ])
+        np.testing.assert_allclose(reg.h[0].toarray()[0],h,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [8.34637805e02, -2.16932259e01, -1.33327894e01, 1.65840848e00],
-                [-2.16932259e01, 5.97683070e-01, 3.39503523e-01, -3.90111107e-02],
-                [-1.33327894e01, 3.39503523e-01, 2.19008080e-01, -2.81929695e-02],
-                [1.65840848e00, -3.90111107e-02, -2.81929695e-02, 3.15686105e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
-        hth = np.array(
-            [
-                [49.0, 704.371999, 139.75],
-                [704.371999, 11686.67338121, 2246.12800625],
-                [139.75, 2246.12800625, 498.5851],
-            ]
-        )
-        np.testing.assert_allclose(reg.hth, hth, RTOL)
-
-
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  8.34637805e+02,  -2.16932259e+01,  -1.33327894e+01,
+                  1.65840848e+00],
+               [ -2.16932259e+01,   5.97683070e-01,   3.39503523e-01,
+                 -3.90111107e-02],
+               [ -1.33327894e+01,   3.39503523e-01,   2.19008080e-01,
+                 -2.81929695e-02],
+               [  1.65840848e+00,  -3.90111107e-02,  -2.81929695e-02,
+                  3.15686105e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
+        hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
+               [   704.371999  ,  11686.67338121,   2246.12800625],
+               [   139.75      ,   2246.12800625,    498.5851    ]])
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
+        
 class TestGMEndogErrorHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
@@ -232,366 +204,213 @@ class TestGMEndogErrorHet(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
-        reg = HET.GM_Endog_Error_Het(
-            self.y, self.X, self.yd, self.q, self.w, step1c=True
-        )
-        betas = np.array([[55.39707924], [0.46563046], [-0.67038326], [0.41135023]])
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([26.51812895])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        predy = np.array([53.94887405])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        reg = HET.GM_Endog_Error_Het(self.y, self.X, self.yd, self.q, self.w, step1c=True)
+        betas = np.array([[ 55.39707924], [  0.46563046], [ -0.67038326], [  0.41135023]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 26.51812895])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        predy = np.array([ 53.94887405])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_allclose(reg.x[0].toarray()[0], x, RTOL)
-        yend = np.array([15.72598])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        q = np.array([5.03])
-        np.testing.assert_allclose(reg.q[0], q, RTOL)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.z[0].toarray()[0], z, RTOL)
-        h = np.array([1.0, 19.531, 5.03])
-        np.testing.assert_allclose(reg.h[0].toarray()[0], h, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.   ,  19.531])
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
+        yend = np.array([ 15.72598])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        q = np.array([ 5.03])
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.z[0].toarray()[0],z,RTOL)
+        h = np.array([  1.   ,  19.531,   5.03 ])
+        np.testing.assert_allclose(reg.h[0].toarray()[0],h,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [8.34637805e02, -2.16932259e01, -1.33327894e01, 1.65840848e00],
-                [-2.16932259e01, 5.97683070e-01, 3.39503523e-01, -3.90111107e-02],
-                [-1.33327894e01, 3.39503523e-01, 2.19008080e-01, -2.81929695e-02],
-                [1.65840848e00, -3.90111107e-02, -2.81929695e-02, 3.15686105e-02],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  8.34637805e+02,  -2.16932259e+01,  -1.33327894e+01,
+                  1.65840848e+00],
+               [ -2.16932259e+01,   5.97683070e-01,   3.39503523e-01,
+                 -3.90111107e-02],
+               [ -1.33327894e+01,   3.39503523e-01,   2.19008080e-01,
+                 -2.81929695e-02],
+               [  1.65840848e+00,  -3.90111107e-02,  -2.81929695e-02,
+                  3.15686105e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.34648011338954804
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
-        std_err = np.array([28.89009873, 0.77309965, 0.46798299, 0.17767558])
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                (1.9175109006819244, 0.055173057472126787),
-                (0.60229035155742305, 0.54698088217644414),
-                (-1.4324949211864271, 0.15200223057569454),
-                (2.3151759776869496, 0.020603303355572443),
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-        hth = np.array(
-            [
-                [49.0, 704.371999, 139.75],
-                [704.371999, 11686.67338121, 2246.12800625],
-                [139.75, 2246.12800625, 498.5851],
-            ]
-        )
-        np.testing.assert_allclose(reg.hth, hth, RTOL)
-
-
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
+        std_err = np.array([ 28.89009873,  0.77309965,  0.46798299,
+            0.17767558])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([(1.9175109006819244, 0.055173057472126787), (0.60229035155742305, 0.54698088217644414), (-1.4324949211864271, 0.15200223057569454), (2.3151759776869496, 0.020603303355572443)])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
+        hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
+               [   704.371999  ,  11686.67338121,   2246.12800625],
+               [   139.75      ,   2246.12800625,    498.5851    ]])
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
+ 
 class TestBaseGMComboHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         # Only spatial lag
         yd2, q2 = spreg.utils.set_endog(self.y, self.X, self.w, None, None, 1, True)
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
-        reg = HET.BaseGM_Combo_Het(
-            self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, step1c=True
-        )
-        betas = np.array(
-            [[57.7778574], [0.73034922], [-0.59257362], [-0.2230231], [0.56636724]]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([25.65156033])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([31.87664403])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        predy = np.array([54.81544267])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        reg = HET.BaseGM_Combo_Het(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, step1c=True)
+        betas = np.array([[ 57.7778574 ], [  0.73034922], [ -0.59257362], [ -0.2230231 ], [  0.56636724]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 25.65156033])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 31.87664403])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        predy = np.array([ 54.81544267])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0].toarray()[0], x, RTOL)
-        yend = np.array([35.4585005])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        q = np.array([18.594, 24.7142675])
-        np.testing.assert_allclose(reg.q[0], q, RTOL)
-        z = np.array([1.0, 19.531, 15.72598, 35.4585005])
-        np.testing.assert_allclose(reg.z[0].toarray()[0], z, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
+        yend = np.array([ 35.4585005])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        q = np.array([ 18.594    ,  24.7142675])
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
+        z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
+        np.testing.assert_allclose(reg.z[0].toarray()[0],z,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy, RTOL)
-        vm = np.array(
-            [
-                [
-                    4.86218274e02,
-                    -2.77268729e00,
-                    -1.59987770e00,
-                    -1.01969471e01,
-                    2.74302006e00,
-                ],
-                [
-                    -2.77268729e00,
-                    1.04680972e-01,
-                    2.51172238e-02,
-                    1.95136385e-03,
-                    3.70052723e-03,
-                ],
-                [
-                    -1.59987770e00,
-                    2.51172238e-02,
-                    2.15655720e-02,
-                    7.65868344e-03,
-                    -7.30173070e-03,
-                ],
-                [
-                    -1.01969471e01,
-                    1.95136385e-03,
-                    7.65868344e-03,
-                    2.78273684e-01,
-                    -6.89402590e-02,
-                ],
-                [
-                    2.74302006e00,
-                    3.70052723e-03,
-                    -7.30173070e-03,
-                    -6.89402590e-02,
-                    7.12034037e-02,
-                ],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
-        hth = np.array(
-            [
-                [
-                    4.90000000e01,
-                    7.04371999e02,
-                    1.72131237e03,
-                    7.24743592e02,
-                    1.70735413e03,
-                ],
-                [
-                    7.04371999e02,
-                    1.16866734e04,
-                    2.15575320e04,
-                    1.10925200e04,
-                    2.23848036e04,
-                ],
-                [
-                    1.72131237e03,
-                    2.15575320e04,
-                    7.39058986e04,
-                    2.34796298e04,
-                    6.70145378e04,
-                ],
-                [
-                    7.24743592e02,
-                    1.10925200e04,
-                    2.34796298e04,
-                    1.16146226e04,
-                    2.30304624e04,
-                ],
-                [
-                    1.70735413e03,
-                    2.23848036e04,
-                    6.70145378e04,
-                    2.30304624e04,
-                    6.69879858e04,
-                ],
-            ]
-        )
-        np.testing.assert_allclose(reg.hth, hth, RTOL)
-
+        np.testing.assert_allclose(reg.std_y,stdy,RTOL)
+        vm = np.array([[  4.86218274e+02,  -2.77268729e+00,  -1.59987770e+00,
+             -1.01969471e+01,   2.74302006e+00],
+           [ -2.77268729e+00,   1.04680972e-01,   2.51172238e-02,
+              1.95136385e-03,   3.70052723e-03],
+           [ -1.59987770e+00,   2.51172238e-02,   2.15655720e-02,
+              7.65868344e-03,  -7.30173070e-03],
+           [ -1.01969471e+01,   1.95136385e-03,   7.65868344e-03,
+              2.78273684e-01,  -6.89402590e-02],
+           [  2.74302006e+00,   3.70052723e-03,  -7.30173070e-03,
+             -6.89402590e-02,   7.12034037e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL*10)
+        hth = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03,
+              7.24743592e+02,   1.70735413e+03],
+           [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04,
+              1.10925200e+04,   2.23848036e+04],
+           [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04,
+              2.34796298e+04,   6.70145378e+04],
+           [  7.24743592e+02,   1.10925200e+04,   2.34796298e+04,
+              1.16146226e+04,   2.30304624e+04],
+           [  1.70735413e+03,   2.23848036e+04,   6.70145378e+04,
+              2.30304624e+04,   6.69879858e+04]])
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
 class TestGMComboHet(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
 
     def test_model(self):
         # Only spatial lag
         reg = HET.GM_Combo_Het(self.y, self.X, w=self.w, step1c=True)
-        betas = np.array(
-            [[57.7778574], [0.73034922], [-0.59257362], [-0.2230231], [0.56636724]]
-        )
-        np.testing.assert_allclose(reg.betas, betas, RTOL)
-        u = np.array([25.65156033])
-        np.testing.assert_allclose(reg.u[0], u, RTOL)
-        ef = np.array([31.87664403])
-        np.testing.assert_allclose(reg.e_filtered[0], ef, RTOL)
-        ep = np.array([28.30648145])
-        np.testing.assert_allclose(reg.e_pred[0], ep, RTOL)
-        pe = np.array([52.16052155])
-        np.testing.assert_allclose(reg.predy_e[0], pe, RTOL)
-        predy = np.array([54.81544267])
-        np.testing.assert_allclose(reg.predy[0], predy, RTOL)
+        betas = np.array([[ 57.7778574 ], [  0.73034922], [ -0.59257362], [ -0.2230231 ], [  0.56636724]])
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        u = np.array([ 25.65156033])
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        ef = np.array([ 31.87664403])
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
+        ep = np.array([ 28.30648145])
+        np.testing.assert_allclose(reg.e_pred[0],ep,RTOL)
+        pe = np.array([ 52.16052155])
+        np.testing.assert_allclose(reg.predy_e[0],pe,RTOL)
+        predy = np.array([ 54.81544267])
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n, n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        np.testing.assert_allclose(reg.k, k)
-        y = np.array([80.467003])
-        np.testing.assert_allclose(reg.y[0], y, RTOL)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_allclose(reg.x[0].toarray()[0], x, RTOL)
-        yend = np.array([35.4585005])
-        np.testing.assert_allclose(reg.yend[0], yend, RTOL)
-        q = np.array([18.594, 24.7142675])
-        np.testing.assert_allclose(reg.q[0].toarray()[0], q, RTOL)
-        z = np.array([1.0, 19.531, 15.72598, 35.4585005])
-        np.testing.assert_allclose(reg.z[0].toarray()[0], z, RTOL)
-        i_s = "Maximum number of iterations reached."
-        np.testing.assert_string_equal(reg.iter_stop, i_s)
+        np.testing.assert_allclose(reg.k,k)
+        y = np.array([ 80.467003])
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
+        yend = np.array([ 35.4585005])
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
+        q = np.array([ 18.594    ,  24.7142675])
+        np.testing.assert_allclose(reg.q[0].toarray()[0],q,RTOL)
+        z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
+        np.testing.assert_allclose(reg.z[0].toarray()[0],z,RTOL)
+        i_s = 'Maximum number of iterations reached.'
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        np.testing.assert_allclose(reg.iteration, its, RTOL)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        np.testing.assert_allclose(reg.mean_y, my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y, stdy)
-        vm = np.array(
-            [
-                [
-                    4.86218274e02,
-                    -2.77268729e00,
-                    -1.59987770e00,
-                    -1.01969471e01,
-                    2.74302006e00,
-                ],
-                [
-                    -2.77268729e00,
-                    1.04680972e-01,
-                    2.51172238e-02,
-                    1.95136385e-03,
-                    3.70052723e-03,
-                ],
-                [
-                    -1.59987770e00,
-                    2.51172238e-02,
-                    2.15655720e-02,
-                    7.65868344e-03,
-                    -7.30173070e-03,
-                ],
-                [
-                    -1.01969471e01,
-                    1.95136385e-03,
-                    7.65868344e-03,
-                    2.78273684e-01,
-                    -6.89402590e-02,
-                ],
-                [
-                    2.74302006e00,
-                    3.70052723e-03,
-                    -7.30173070e-03,
-                    -6.89402590e-02,
-                    7.12034037e-02,
-                ],
-            ]
-        )
-        np.testing.assert_allclose(reg.vm, vm, RTOL)
+        np.testing.assert_allclose(reg.std_y,stdy)
+        vm = np.array([[  4.86218274e+02,  -2.77268729e+00,  -1.59987770e+00,
+             -1.01969471e+01,   2.74302006e+00],
+           [ -2.77268729e+00,   1.04680972e-01,   2.51172238e-02,
+              1.95136385e-03,   3.70052723e-03],
+           [ -1.59987770e+00,   2.51172238e-02,   2.15655720e-02,
+              7.65868344e-03,  -7.30173070e-03],
+           [ -1.01969471e+01,   1.95136385e-03,   7.65868344e-03,
+              2.78273684e-01,  -6.89402590e-02],
+           [  2.74302006e+00,   3.70052723e-03,  -7.30173070e-03,
+             -6.89402590e-02,   7.12034037e-02]])
+        np.testing.assert_allclose(reg.vm,vm,RTOL*10)
         pr2 = 0.3001582877472412
-        np.testing.assert_allclose(reg.pr2, pr2, RTOL)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.35613102283621967
-        np.testing.assert_allclose(reg.pr2_e, pr2_e, RTOL)
-        std_err = np.array(
-            [22.05035768, 0.32354439, 0.14685221, 0.52751653, 0.26683966]
-        )
-        np.testing.assert_allclose(reg.std_err, std_err, RTOL)
-        z_stat = np.array(
-            [
-                (2.6202684885795335, 0.00878605635338265),
-                (2.2573385444145524, 0.023986928627746887),
-                (-4.0351698589183433, 5.456281036278686e-05),
-                (-0.42277935292121521, 0.67245625315942159),
-                (2.1225002455741895, 0.033795752094112265),
-            ]
-        )
-        np.testing.assert_allclose(reg.z_stat, z_stat, RTOL)
-        hth = np.array(
-            [
-                [
-                    4.90000000e01,
-                    7.04371999e02,
-                    1.72131237e03,
-                    7.24743592e02,
-                    1.70735413e03,
-                ],
-                [
-                    7.04371999e02,
-                    1.16866734e04,
-                    2.15575320e04,
-                    1.10925200e04,
-                    2.23848036e04,
-                ],
-                [
-                    1.72131237e03,
-                    2.15575320e04,
-                    7.39058986e04,
-                    2.34796298e04,
-                    6.70145378e04,
-                ],
-                [
-                    7.24743592e02,
-                    1.10925200e04,
-                    2.34796298e04,
-                    1.16146226e04,
-                    2.30304624e04,
-                ],
-                [
-                    1.70735413e03,
-                    2.23848036e04,
-                    6.70145378e04,
-                    2.30304624e04,
-                    6.69879858e04,
-                ],
-            ]
-        )
-        np.testing.assert_allclose(reg.hth, hth, RTOL)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
+        std_err = np.array([ 22.05035768,  0.32354439,  0.14685221,  0.52751653,  0.26683966])
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        z_stat = np.array([(2.6202684885795335, 0.00878605635338265), (2.2573385444145524, 0.023986928627746887), (-4.0351698589183433, 5.456281036278686e-05), (-0.42277935292121521, 0.67245625315942159), (2.1225002455741895, 0.033795752094112265)])
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
+        hth = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03,
+              7.24743592e+02,   1.70735413e+03],
+           [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04,
+              1.10925200e+04,   2.23848036e+04],
+           [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04,
+              2.34796298e+04,   6.70145378e+04],
+           [  7.24743592e+02,   1.10925200e+04,   2.34796298e+04,
+              1.16146226e+04,   2.30304624e+04],
+           [  1.70735413e+03,   2.23848036e+04,   6.70145378e+04,
+              2.30304624e+04,   6.69879858e+04]])
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/spreg/tests/test_error_sp_hom_sparse.py
+++ b/spreg/tests/test_error_sp_hom_sparse.py
@@ -1,7 +1,7 @@
-"""
+'''
 Unittests for spreg.error_sp_hom module
 
-"""
+'''
 import unittest
 import libpysal
 from spreg import error_sp_hom as HOM
@@ -9,139 +9,94 @@ from scipy import sparse
 import numpy as np
 import spreg
 
-
 class BaseGM_Error_Hom_Tester(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
     def test_model(self):
-        reg = HOM.BaseGM_Error_Hom(self.y, self.X, self.w.sparse, A1="hom_sc")
-        np.testing.assert_array_almost_equal(reg.y[0], np.array([80.467003]), 7)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0], x, 7)
-        betas = np.array([[47.9478524], [0.70633223], [-0.55595633], [0.41288558]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
-        np.testing.assert_array_almost_equal(reg.u[0], np.array([27.466734]), 6)
-        np.testing.assert_array_almost_equal(
-            reg.e_filtered[0], np.array([32.37298547]), 7
-        )
-        i_s = "Maximum number of iterations reached."
-        self.assertAlmostEqual(reg.iter_stop, i_s, 7)
-        np.testing.assert_array_almost_equal(reg.predy[0], np.array([53.000269]), 6)
-        self.assertAlmostEqual(reg.n, 49, 7)
-        self.assertAlmostEqual(reg.k, 3, 7)
+        reg = HOM.BaseGM_Error_Hom(self.y, self.X, self.w.sparse, A1='hom_sc')
+        np.testing.assert_array_almost_equal(reg.y[0],np.array([80.467003]),7)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        betas = np.array([[ 47.9478524 ], [  0.70633223], [ -0.55595633], [  0.41288558]])
+        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_array_almost_equal(reg.u[0],np.array([27.466734]),6)
+        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 32.37298547]),5)
+        i_s = 'Maximum number of iterations reached.'
+        self.assertAlmostEqual(reg.iter_stop,i_s,7)
+        np.testing.assert_array_almost_equal(reg.predy[0],np.array([ 53.000269]),6)
+        self.assertAlmostEqual(reg.n,49,7)
+        self.assertAlmostEqual(reg.k,3,7)
         sig2 = 189.94459439729718
-        self.assertAlmostEqual(reg.sig2, sig2)
-        vm = np.array(
-            [
-                [1.51340717e02, -5.29057506e00, -1.85654540e00, -2.39139054e-03],
-                [-5.29057506e00, 2.46669610e-01, 5.14259101e-02, 3.19241302e-04],
-                [-1.85654540e00, 5.14259101e-02, 3.20510550e-02, -5.95640240e-05],
-                [-2.39139054e-03, 3.19241302e-04, -5.95640240e-05, 3.36690159e-02],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
-        xtx = np.array(
-            [
-                [4.90000000e01, 7.04371999e02, 1.72131237e03],
-                [7.04371999e02, 1.16866734e04, 2.15575320e04],
-                [1.72131237e03, 2.15575320e04, 7.39058986e04],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.xtx, xtx, 4)
-
+        self.assertAlmostEqual(reg.sig2,sig2,5)
+        vm = np.array([[  1.51340717e+02,  -5.29057506e+00,  -1.85654540e+00, -2.39139054e-03], [ -5.29057506e+00,   2.46669610e-01, 5.14259101e-02, 3.19241302e-04], [ -1.85654540e+00,   5.14259101e-02, 3.20510550e-02,  -5.95640240e-05], [ -2.39139054e-03,   3.19241302e-04, -5.95640240e-05,  3.36690159e-02]])
+        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        xtx = np.array([[  4.90000000e+01,   7.04371999e+02, 1.72131237e+03], [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04], [  1.72131237e+03,   2.15575320e+04, 7.39058986e+04]])
+        np.testing.assert_array_almost_equal(reg.xtx,xtx,4)
 
 class GM_Error_Hom_Tester(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         X.append(db.by_col("CRIME"))
         self.X = np.array(X).T
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
     def test_model(self):
-        reg = HOM.GM_Error_Hom(self.y, self.X, self.w, A1="hom_sc")
-        np.testing.assert_array_almost_equal(reg.y[0], np.array([80.467003]), 7)
-        x = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0], x, 7)
-        betas = np.array([[47.9478524], [0.70633223], [-0.55595633], [0.41288558]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
-        np.testing.assert_array_almost_equal(reg.u[0], np.array([27.46673388]), 6)
-        np.testing.assert_array_almost_equal(
-            reg.e_filtered[0], np.array([32.37298547]), 7
-        )
-        np.testing.assert_array_almost_equal(reg.predy[0], np.array([53.00026912]), 6)
-        self.assertAlmostEqual(reg.n, 49, 7)
-        self.assertAlmostEqual(reg.k, 3, 7)
-        vm = np.array(
-            [
-                [1.51340717e02, -5.29057506e00, -1.85654540e00, -2.39139054e-03],
-                [-5.29057506e00, 2.46669610e-01, 5.14259101e-02, 3.19241302e-04],
-                [-1.85654540e00, 5.14259101e-02, 3.20510550e-02, -5.95640240e-05],
-                [-2.39139054e-03, 3.19241302e-04, -5.95640240e-05, 3.36690159e-02],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
-        i_s = "Maximum number of iterations reached."
-        self.assertAlmostEqual(reg.iter_stop, i_s, 7)
-        self.assertAlmostEqual(reg.iteration, 1, 7)
+        reg = HOM.GM_Error_Hom(self.y, self.X, self.w, A1='hom_sc')
+        np.testing.assert_array_almost_equal(reg.y[0],np.array([80.467003]),7)
+        x = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        betas = np.array([[ 47.9478524 ], [  0.70633223], [ -0.55595633], [  0.41288558]])
+        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_array_almost_equal(reg.u[0],np.array([27.46673388]),6)
+        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 32.37298547]),5)
+        np.testing.assert_array_almost_equal(reg.predy[0],np.array([ 53.00026912]),6)
+        self.assertAlmostEqual(reg.n,49,7)
+        self.assertAlmostEqual(reg.k,3,7)
+        vm = np.array([[  1.51340717e+02,  -5.29057506e+00,  -1.85654540e+00, -2.39139054e-03], [ -5.29057506e+00,   2.46669610e-01, 5.14259101e-02, 3.19241302e-04], [ -1.85654540e+00,   5.14259101e-02, 3.20510550e-02,  -5.95640240e-05], [ -2.39139054e-03,   3.19241302e-04, -5.95640240e-05,  3.36690159e-02]])
+        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        i_s = 'Maximum number of iterations reached.'
+        self.assertAlmostEqual(reg.iter_stop,i_s,7)
+        self.assertAlmostEqual(reg.iteration,1,7)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y, my)
+        self.assertAlmostEqual(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y, std_y)
+        self.assertAlmostEqual(reg.std_y,std_y)
         pr2 = 0.34950977055969729
-        self.assertAlmostEqual(reg.pr2, pr2)
+        self.assertAlmostEqual(reg.pr2,pr2)
         sig2 = 189.94459439729718
-        self.assertAlmostEqual(reg.sig2, sig2)
-        std_err = np.array([12.30206149, 0.49665844, 0.17902808, 0.18349119])
-        np.testing.assert_array_almost_equal(reg.std_err, std_err, 6)
-        z_stat = np.array(
-            [
-                [3.89754616e00, 9.71723059e-05],
-                [1.42216900e00, 1.54977196e-01],
-                [-3.10541409e00, 1.90012806e-03],
-                [2.25016500e00, 2.44384731e-02],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.z_stat, z_stat, 6)
-        xtx = np.array(
-            [
-                [4.90000000e01, 7.04371999e02, 1.72131237e03],
-                [7.04371999e02, 1.16866734e04, 2.15575320e04],
-                [1.72131237e03, 2.15575320e04, 7.39058986e04],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.xtx, xtx, 4)
+        self.assertAlmostEqual(reg.sig2,sig2,5)
+        std_err = np.array([ 12.30206149,   0.49665844,   0.17902808, 0.18349119])
+        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        z_stat = np.array([[  3.89754616e+00,   9.71723059e-05], [  1.42216900e+00,   1.54977196e-01], [ -3.10541409e+00,   1.90012806e-03], [  2.25016500e+00,   2.44384731e-02]])
+        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        xtx = np.array([[  4.90000000e+01,   7.04371999e+02, 1.72131237e+03], [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04], [  1.72131237e+03,   2.15575320e+04, 7.39058986e+04]])
+        np.testing.assert_array_almost_equal(reg.xtx,xtx,4)
 
 
 class BaseGM_Endog_Error_Hom_Tester(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
         yd = []
         yd.append(db.by_col("CRIME"))
@@ -149,73 +104,52 @@ class BaseGM_Endog_Error_Hom_Tester(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
     def test_model(self):
-        reg = HOM.BaseGM_Endog_Error_Hom(
-            self.y, self.X, self.yd, self.q, self.w.sparse, A1="hom_sc"
-        )
-        np.testing.assert_array_almost_equal(reg.y[0], np.array([80.467003]), 7)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0], x, 7)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0], z, 7)
-        h = np.array([1.0, 19.531, 5.03])
-        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0], h, 7)
-        yend = np.array([15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0], yend, 7)
-        q = np.array([5.03])
-        np.testing.assert_array_almost_equal(reg.q[0], q, 7)
-        betas = np.array([[55.36575166], [0.46432416], [-0.66904404], [0.43205526]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 6)
-        u = np.array([26.55390939])
-        np.testing.assert_array_almost_equal(reg.u[0], u, 6)
-        np.testing.assert_array_almost_equal(
-            reg.e_filtered[0], np.array([31.74114306]), 7
-        )
-        predy = np.array([53.91309361])
-        np.testing.assert_array_almost_equal(reg.predy[0], predy, 6)
-        self.assertAlmostEqual(reg.n, 49, 7)
-        self.assertAlmostEqual(reg.k, 3, 7)
+        reg = HOM.BaseGM_Endog_Error_Hom(self.y, self.X, self.yd, self.q, self.w.sparse, A1='hom_sc')
+        np.testing.assert_array_almost_equal(reg.y[0],np.array([ 80.467003]),7)
+        x = np.array([  1.     ,  19.531])
+        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0],z,7)
+        h = np.array([  1.   ,  19.531,   5.03 ])
+        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0],h,7)
+        yend = np.array([ 15.72598])
+        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        q = np.array([ 5.03])
+        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        betas = np.array([[ 55.36575166], [  0.46432416], [ -0.66904404], [  0.43205526]])
+        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        u = np.array([ 26.55390939])
+        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 31.74114306]),5)
+        predy = np.array([ 53.91309361])
+        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        self.assertAlmostEqual(reg.n,49,7)
+        self.assertAlmostEqual(reg.k,3,7)
         sig2 = 190.59435238060928
-        self.assertAlmostEqual(reg.sig2, sig2)
-        vm = np.array(
-            [
-                [5.52064057e02, -1.61264555e01, -8.86360735e00, 1.04251912e00],
-                [-1.61264555e01, 5.44898242e-01, 2.39518645e-01, -1.88092950e-02],
-                [-8.86360735e00, 2.39518645e-01, 1.55501840e-01, -2.18638648e-02],
-                [1.04251912e00, -1.88092950e-02, -2.18638648e-02, 3.71222222e-02],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
-        i_s = "Maximum number of iterations reached."
-        self.assertAlmostEqual(reg.iter_stop, i_s, 7)
+        self.assertAlmostEqual(reg.sig2,sig2,4)
+        vm = np.array([[  5.52064057e+02,  -1.61264555e+01,  -8.86360735e+00, 1.04251912e+00], [ -1.61264555e+01,   5.44898242e-01, 2.39518645e-01, -1.88092950e-02], [ -8.86360735e+00,   2.39518645e-01, 1.55501840e-01, -2.18638648e-02], [  1.04251912e+00, -1.88092950e-02, -2.18638648e-02, 3.71222222e-02]])
+        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        i_s = 'Maximum number of iterations reached.'
+        self.assertAlmostEqual(reg.iter_stop,i_s,7)
         its = 1
-        self.assertAlmostEqual(reg.iteration, its, 7)
+        self.assertAlmostEqual(reg.iteration,its,7)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y, my)
+        self.assertAlmostEqual(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y, std_y)
+        self.assertAlmostEqual(reg.std_y,std_y)
         sig2 = 0
-        # self.assertAlmostEqual(reg.sig2,sig2)
-        hth = np.array(
-            [
-                [49.0, 704.371999, 139.75],
-                [704.371999, 11686.67338121, 2246.12800625],
-                [139.75, 2246.12800625, 498.5851],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.hth, hth, 4)
-
+        #self.assertAlmostEqual(reg.sig2,sig2)
+        hth = np.array([[    49.        ,    704.371999  ,    139.75      ], [   704.371999  ,  11686.67338121,   2246.12800625], [   139.75      ,   2246.12800625,    498.5851]])
+        np.testing.assert_array_almost_equal(reg.hth,hth,4)
 
 class GM_Endog_Error_Hom_Tester(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
@@ -226,227 +160,162 @@ class GM_Endog_Error_Hom_Tester(unittest.TestCase):
         q = []
         q.append(db.by_col("DISCBD"))
         self.q = np.array(q).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
     def test_model(self):
-        reg = HOM.GM_Endog_Error_Hom(
-            self.y, self.X, self.yd, self.q, self.w, A1="hom_sc"
-        )
-        np.testing.assert_array_almost_equal(reg.y[0], np.array([80.467003]), 7)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0], x, 7)
-        z = np.array([1.0, 19.531, 15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0], z, 7)
-        h = np.array([1.0, 19.531, 5.03])
-        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0], h, 7)
-        yend = np.array([15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0], yend, 7)
-        q = np.array([5.03])
-        np.testing.assert_array_almost_equal(reg.q[0], q, 7)
-        betas = np.array([[55.36575166], [0.46432416], [-0.66904404], [0.43205526]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 6)
-        u = np.array([26.55390939])
-        np.testing.assert_array_almost_equal(reg.u[0], u, 6)
-        np.testing.assert_array_almost_equal(
-            reg.e_filtered[0], np.array([31.74114306]), 7
-        )
-        predy = np.array([53.91309361])
-        np.testing.assert_array_almost_equal(reg.predy[0], predy, 6)
-        self.assertAlmostEqual(reg.n, 49, 7)
-        self.assertAlmostEqual(reg.k, 3, 7)
-        vm = np.array(
-            [
-                [5.52064057e02, -1.61264555e01, -8.86360735e00, 1.04251912e00],
-                [-1.61264555e01, 5.44898242e-01, 2.39518645e-01, -1.88092950e-02],
-                [-8.86360735e00, 2.39518645e-01, 1.55501840e-01, -2.18638648e-02],
-                [1.04251912e00, -1.88092950e-02, -2.18638648e-02, 3.71222222e-02],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
-        i_s = "Maximum number of iterations reached."
-        self.assertAlmostEqual(reg.iter_stop, i_s, 7)
+        reg = HOM.GM_Endog_Error_Hom(self.y, self.X, self.yd, self.q, self.w, A1='hom_sc')
+        np.testing.assert_array_almost_equal(reg.y[0],np.array([ 80.467003]),7)
+        x = np.array([  1.     ,  19.531])
+        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        z = np.array([  1.     ,  19.531  ,  15.72598])
+        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0],z,7)
+        h = np.array([  1.   ,  19.531,   5.03 ])
+        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0],h,7)
+        yend = np.array([ 15.72598])
+        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        q = np.array([ 5.03])
+        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        betas = np.array([[ 55.36575166], [  0.46432416], [ -0.66904404], [  0.43205526]])
+        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        u = np.array([ 26.55390939])
+        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 31.74114]),5)
+        predy = np.array([ 53.91309361])
+        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        self.assertAlmostEqual(reg.n,49,7)
+        self.assertAlmostEqual(reg.k,3,7)
+        vm = np.array([[  5.52064057e+02,  -1.61264555e+01,  -8.86360735e+00, 1.04251912e+00], [ -1.61264555e+01,   5.44898242e-01, 2.39518645e-01, -1.88092950e-02], [ -8.86360735e+00,   2.39518645e-01, 1.55501840e-01, -2.18638648e-02], [  1.04251912e+00, -1.88092950e-02, -2.18638648e-02, 3.71222222e-02]])
+        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        i_s = 'Maximum number of iterations reached.'
+        self.assertAlmostEqual(reg.iter_stop,i_s,7)
         its = 1
-        self.assertAlmostEqual(reg.iteration, its, 7)
+        self.assertAlmostEqual(reg.iteration,its,7)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y, my)
+        self.assertAlmostEqual(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y, std_y)
+        self.assertAlmostEqual(reg.std_y,std_y)
         pr2 = 0.34647366525657419
-        self.assertAlmostEqual(reg.pr2, pr2)
+        self.assertAlmostEqual(reg.pr2,pr2)
         sig2 = 190.59435238060928
-        self.assertAlmostEqual(reg.sig2, sig2)
-        # std_err
-        std_err = np.array([23.49604343, 0.73817223, 0.39433722, 0.19267128])
-        np.testing.assert_array_almost_equal(reg.std_err, std_err, 6)
-        z_stat = np.array(
-            [
-                [2.35638617, 0.01845372],
-                [0.62901874, 0.52933679],
-                [-1.69662923, 0.08976678],
-                [2.24244556, 0.02493259],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.z_stat, z_stat, 6)
+        self.assertAlmostEqual(reg.sig2,sig2,4)
+        #std_err
+        std_err = np.array([ 23.49604343,   0.73817223,   0.39433722, 0.19267128])
+        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        z_stat = np.array([[ 2.35638617,  0.01845372], [ 0.62901874,  0.52933679], [-1.69662923,  0.08976678], [ 2.24244556,  0.02493259]])
+        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
 
 
 class BaseGM_Combo_Hom_Tester(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
     def test_model(self):
         yd2, q2 = spreg.utils.set_endog(self.y, self.X, self.w, None, None, 1, True)
-        self.X = np.hstack((np.ones(self.y.shape), self.X))
+        self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
-        reg = HOM.BaseGM_Combo_Hom(
-            self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, A1="hom_sc"
-        )
-        np.testing.assert_array_almost_equal(reg.y[0], np.array([80.467003]), 7)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0], x, 7)
-        betas = np.array([[10.12541428], [1.56832263], [0.15132076], [0.21033397]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
-        np.testing.assert_array_almost_equal(reg.u[0], np.array([34.3450723]), 7)
-        np.testing.assert_array_almost_equal(
-            reg.e_filtered[0], np.array([36.6149682]), 7
-        )
-        np.testing.assert_array_almost_equal(reg.predy[0], np.array([46.1219307]), 7)
-        self.assertAlmostEqual(reg.n, 49, 7)
-        self.assertAlmostEqual(reg.k, 3, 7)
-        vm = np.array(
-            [
-                [2.33694742e02, -6.66856869e-01, -5.58304254e00, 4.85488380e00],
-                [-6.66856869e-01, 1.94241504e-01, -5.42327138e-02, 5.37225570e-02],
-                [-5.58304254e00, -5.42327138e-02, 1.63860721e-01, -1.44425498e-01],
-                [4.85488380e00, 5.37225570e-02, -1.44425498e-01, 1.78622255e-01],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
-        z = np.array([1.0, 19.531, 35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0], z, 7)
-        h = np.array([1.0, 19.531, 18.594])
-        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0], h, 7)
-        yend = np.array([35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0], yend, 7)
-        q = np.array([18.594])
-        np.testing.assert_array_almost_equal(reg.q[0], q, 7)
-        i_s = "Maximum number of iterations reached."
-        self.assertAlmostEqual(reg.iter_stop, i_s, 7)
+        reg = HOM.BaseGM_Combo_Hom(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, A1='hom_sc')
+        np.testing.assert_array_almost_equal(reg.y[0],np.array([80.467003]),7)
+        x = np.array([  1.     ,  19.531])
+        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        betas = np.array([[ 10.12541428], [  1.56832263], [  0.15132076], [  0.21033397]])
+        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_array_almost_equal(reg.u[0],np.array([34.3450723]),7)
+        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 36.6149682]),7)
+        np.testing.assert_array_almost_equal(reg.predy[0],np.array([ 46.1219307]),7)
+        self.assertAlmostEqual(reg.n,49,7)
+        self.assertAlmostEqual(reg.k,3,7)
+        vm = np.array([[  2.33694742e+02,  -6.66856869e-01,  -5.58304254e+00, 4.85488380e+00], [ -6.66856869e-01,   1.94241504e-01, -5.42327138e-02, 5.37225570e-02], [ -5.58304254e+00,  -5.42327138e-02, 1.63860721e-01, -1.44425498e-01], [  4.85488380e+00, 5.37225570e-02, -1.44425498e-01, 1.78622255e-01]])
+        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        z = np.array([  1.       ,  19.531    ,  35.4585005])
+        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0],z,7)
+        h = np.array([  1.   ,  19.531,  18.594])
+        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0],h,7)
+        yend = np.array([ 35.4585005])
+        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        q = np.array([ 18.594])
+        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        i_s = 'Maximum number of iterations reached.'
+        self.assertAlmostEqual(reg.iter_stop,i_s,7)
         its = 1
-        self.assertAlmostEqual(reg.iteration, its, 7)
+        self.assertAlmostEqual(reg.iteration,its,7)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y, my)
+        self.assertAlmostEqual(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y, std_y)
+        self.assertAlmostEqual(reg.std_y,std_y)
         sig2 = 232.22680644168395
-        self.assertAlmostEqual(reg.sig2, sig2, places=6)
-        hth = np.array(
-            [
-                [49.0, 704.371999, 724.7435916],
-                [704.371999, 11686.67338121, 11092.519988],
-                [724.7435916, 11092.519988, 11614.62257048],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.hth, hth, 4)
+        self.assertAlmostEqual(reg.sig2,sig2, places=6)
+        hth = np.array([[    49.        ,    704.371999  ,    724.7435916 ], [   704.371999  ,  11686.67338121,  11092.519988  ], [   724.7435916 ,  11092.519988  , 11614.62257048]])
+        np.testing.assert_array_almost_equal(reg.hth,hth,4)
 
 
 class GM_Combo_Hom_Tester(unittest.TestCase):
     def setUp(self):
-        db = libpysal.io.open(libpysal.examples.get_path("columbus.dbf"), "r")
+        db=libpysal.io.open(libpysal.examples.get_path("columbus.dbf"),"r")
         y = np.array(db.by_col("HOVAL"))
-        self.y = np.reshape(y, (49, 1))
+        self.y = np.reshape(y, (49,1))
         X = []
         X.append(db.by_col("INC"))
         self.X = np.array(X).T
         self.X = sparse.csr_matrix(self.X)
-        self.w = libpysal.weights.Rook.from_shapefile(
-            libpysal.examples.get_path("columbus.shp")
-        )
-        self.w.transform = "r"
-
+        self.w = libpysal.weights.Rook.from_shapefile(libpysal.examples.get_path("columbus.shp"))
+        self.w.transform = 'r'
     def test_model(self):
-        reg = HOM.GM_Combo_Hom(self.y, self.X, w=self.w, A1="hom_sc")
-        np.testing.assert_array_almost_equal(reg.y[0], np.array([80.467003]), 7)
-        x = np.array([1.0, 19.531])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0], x, 7)
-        betas = np.array([[10.12541428], [1.56832263], [0.15132076], [0.21033397]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
-        np.testing.assert_array_almost_equal(reg.u[0], np.array([34.3450723]), 7)
-        np.testing.assert_array_almost_equal(
-            reg.e_filtered[0], np.array([36.6149682]), 7
-        )
-        np.testing.assert_array_almost_equal(reg.e_pred[0], np.array([32.90372983]), 7)
-        np.testing.assert_array_almost_equal(reg.predy[0], np.array([46.1219307]), 7)
-        np.testing.assert_array_almost_equal(reg.predy_e[0], np.array([47.56327317]), 7)
-        self.assertAlmostEqual(reg.n, 49, 7)
-        self.assertAlmostEqual(reg.k, 3, 7)
-        z = np.array([1.0, 19.531, 35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0], z, 7)
-        h = np.array([1.0, 19.531, 18.594])
-        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0], h, 7)
-        yend = np.array([35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0], yend, 7)
-        q = np.array([18.594])
-        np.testing.assert_array_almost_equal(reg.q[0].toarray()[0], q, 7)
-        i_s = "Maximum number of iterations reached."
-        self.assertAlmostEqual(reg.iter_stop, i_s, 7)
-        self.assertAlmostEqual(reg.iteration, 1, 7)
+        reg = HOM.GM_Combo_Hom(self.y, self.X, w=self.w, A1='hom_sc')
+        np.testing.assert_array_almost_equal(reg.y[0],np.array([80.467003]),7)
+        x = np.array([  1.     ,  19.531])
+        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        betas = np.array([[ 10.12541428], [  1.56832263], [  0.15132076], [  0.21033397]])
+        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_array_almost_equal(reg.u[0],np.array([34.3450723]),7)
+        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 36.6149682]),7)
+        np.testing.assert_array_almost_equal(reg.e_pred[0],np.array([ 32.90372983]),7)
+        np.testing.assert_array_almost_equal(reg.predy[0],np.array([ 46.1219307]),7)
+        np.testing.assert_array_almost_equal(reg.predy_e[0],np.array([47.56327317]),7)
+        self.assertAlmostEqual(reg.n,49,7)
+        self.assertAlmostEqual(reg.k,3,7)
+        z = np.array([  1.       ,  19.531    ,  35.4585005])
+        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0],z,7)
+        h = np.array([  1.   ,  19.531,  18.594])
+        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0],h,7)
+        yend = np.array([ 35.4585005])
+        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        q = np.array([ 18.594])
+        np.testing.assert_array_almost_equal(reg.q[0].toarray()[0],q,7)
+        i_s = 'Maximum number of iterations reached.'
+        self.assertAlmostEqual(reg.iter_stop,i_s,7)
+        self.assertAlmostEqual(reg.iteration,1,7)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y, my)
+        self.assertAlmostEqual(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y, std_y)
+        self.assertAlmostEqual(reg.std_y,std_y)
         pr2 = 0.28379825632694394
-        self.assertAlmostEqual(reg.pr2, pr2)
+        self.assertAlmostEqual(reg.pr2,pr2)
         pr2_e = 0.25082892555141506
-        self.assertAlmostEqual(reg.pr2_e, pr2_e)
+        self.assertAlmostEqual(reg.pr2_e,pr2_e)
         sig2 = 232.22680644168395
-        self.assertAlmostEqual(reg.sig2, sig2, places=6)
-        std_err = np.array([15.28707761, 0.44072838, 0.40479714, 0.42263726])
-        np.testing.assert_array_almost_equal(reg.std_err, std_err, 6)
-        z_stat = np.array(
-            [
-                [6.62351206e-01, 5.07746167e-01],
-                [3.55847888e00, 3.73008780e-04],
-                [3.73818749e-01, 7.08539170e-01],
-                [4.97670189e-01, 6.18716523e-01],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.z_stat, z_stat, 6)
-        vm = np.array(
-            [
-                [2.33694742e02, -6.66856869e-01, -5.58304254e00, 4.85488380e00],
-                [-6.66856869e-01, 1.94241504e-01, -5.42327138e-02, 5.37225570e-02],
-                [-5.58304254e00, -5.42327138e-02, 1.63860721e-01, -1.44425498e-01],
-                [4.85488380e00, 5.37225570e-02, -1.44425498e-01, 1.78622255e-01],
-            ]
-        )
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
-
+        self.assertAlmostEqual(reg.sig2,sig2, places=6)
+        std_err = np.array([ 15.28707761,   0.44072838,   0.40479714, 0.42263726])
+        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        z_stat = np.array([[  6.62351206e-01,   5.07746167e-01], [  3.55847888e+00,   3.73008780e-04], [  3.73818749e-01,   7.08539170e-01], [  4.97670189e-01,   6.18716523e-01]])
+        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        vm = np.array([[  2.33694742e+02,  -6.66856869e-01,  -5.58304254e+00, 4.85488380e+00], [ -6.66856869e-01,   1.94241504e-01, -5.42327138e-02, 5.37225570e-02], [ -5.58304254e+00,  -5.42327138e-02, 1.63860721e-01, -1.44425498e-01], [  4.85488380e+00, 5.37225570e-02, -1.44425498e-01, 1.78622255e-01]])
+        np.testing.assert_array_almost_equal(reg.vm,vm,6)
 
 suite = unittest.TestSuite()
-test_classes = [
-    BaseGM_Error_Hom_Tester,
-    GM_Error_Hom_Tester,
-    BaseGM_Endog_Error_Hom_Tester,
-    GM_Endog_Error_Hom_Tester,
-    BaseGM_Combo_Hom_Tester,
-    GM_Combo_Hom_Tester,
-]
+test_classes = [BaseGM_Error_Hom_Tester, GM_Error_Hom_Tester,\
+        BaseGM_Endog_Error_Hom_Tester, GM_Endog_Error_Hom_Tester, \
+        BaseGM_Combo_Hom_Tester, GM_Combo_Hom_Tester]
 for i in test_classes:
     a = unittest.TestLoader().loadTestsFromTestCase(i)
     suite.addTest(a)
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     runner = unittest.TextTestRunner()
     runner.run(suite)
+

--- a/spreg/tests/test_sp_panels.py
+++ b/spreg/tests/test_sp_panels.py
@@ -3,192 +3,87 @@ import numpy as np
 import libpysal
 from libpysal.common import RTOL
 from spreg.sp_panels import *
-
 ATOL = 1e-12
 
 
 class Test_GM_KKP(unittest.TestCase):
     def setUp(self):
-        nat = libpysal.examples.load_example("NCOVR")
-        self.db = libpysal.io.open(nat.get_path("NAT.dbf"), "r")
-        self.w = libpysal.weights.Queen.from_shapefile(
-            libpysal.examples.get_path("NAT.shp")
-        )
-        self.w.transform = "r"
-        self.y_var0 = ["HR70", "HR80", "HR90"]
-        self.x_var0 = ["RD70", "RD80", "RD90", "PS70", "PS80", "PS90"]
+        nat = libpysal.examples.load_example('NCOVR')
+        self.db = libpysal.io.open(nat.get_path("NAT.dbf"),'r')
+        self.w = libpysal.weights.Queen.from_shapefile(libpysal.examples.get_path("NAT.shp"))
+        self.w.transform = 'r'
+        self.y_var0 = ['HR70','HR80','HR90']
+        self.x_var0 = ['RD70','RD80','RD90','PS70','PS80','PS90']
         self.y = np.array([self.db.by_col(name) for name in self.y_var0]).T
         self.x = np.array([self.db.by_col(name) for name in self.x_var0]).T
 
-    def test_wide_ident(self):
-        reg = GM_KKP(
-            self.y,
-            self.x,
-            self.w,
-            full_weights=False,
-            name_y=self.y_var0,
-            name_x=self.x_var0,
-        )
-        np.testing.assert_allclose(
-            reg.betas,
-            np.array(
-                [
-                    [6.49221562],
-                    [3.62445753],
-                    [1.31187779],
-                    [0.41777589],
-                    [22.81908224],
-                    [39.90993228],
-                ]
-            ),
-            RTOL,
-        )
-        np.testing.assert_allclose(
-            reg.vm,
-            np.array(
-                [
-                    [1.26948117e-02, -1.98160325e-06, 7.38157674e-05],
-                    [-1.98160325e-06, 7.69961725e-03, 1.13099329e-03],
-                    [7.38157674e-05, 1.13099329e-03, 7.26783636e-03],
-                ]
-            ),
-            RTOL,
-        )
-        np.testing.assert_equal(
-            reg.name_x, ["CONSTANT", "RD", "PS", "lambda", " sigma2_v", "sigma2_1"]
-        )
-        np.testing.assert_equal(reg.name_y, "HR")
 
-    def test_wide_full(self):
-        reg = GM_KKP(self.y, self.x, self.w, full_weights=True)
+    def test_wide_ident(self): 
+        reg = GM_KKP(self.y,self.x,self.w,full_weights=False,name_y=self.y_var0, name_x=self.x_var0)
+        np.testing.assert_allclose(reg.betas,np.array([[ 6.49221562],
+ [ 3.62445753],
+ [ 1.31187779],
+ [ 0.41777589],
+ [22.81908224],
+ [39.90993228]]),RTOL)
+        np.testing.assert_allclose(reg.vm,np.array([[ 1.26948117e-02, -1.98160325e-06,  7.38157674e-05],
+ [-1.98160325e-06,  7.69961725e-03, 1.13099329e-03],
+ [ 7.38157674e-05,  1.13099329e-03,  7.26783636e-03]]),RTOL*10)
+        np.testing.assert_equal(reg.name_x,  ['CONSTANT', 'RD', 'PS', 'lambda', ' sigma2_v', 'sigma2_1'])
+        np.testing.assert_equal(reg.name_y,  'HR')
 
-        np.testing.assert_allclose(
-            reg.betas,
-            np.array(
-                [
-                    [6.49193589],
-                    [3.55740165],
-                    [1.29462748],
-                    [0.4263399],
-                    [22.47241979],
-                    [45.82593532],
-                ]
-            ),
-            RTOL,
-        )
-        np.testing.assert_allclose(
-            reg.vm,
-            np.array(
-                [
-                    [1.45113773e-02, -2.14882672e-06, 8.54997693e-05],
-                    [-2.14882672e-06, 8.41929187e-03, 1.24553497e-03],
-                    [8.54997693e-05, 1.24553497e-03, 8.12448812e-03],
-                ]
-            ),
-            RTOL,
-        )
+    def test_wide_full(self): 
+        reg = GM_KKP(self.y,self.x,self.w,full_weights=True)
 
-    def test_long_ident(self):
-        bigy = self.y.reshape((self.y.size, 1), order="F")
-        bigx = self.x[:, 0:3].reshape((self.x.shape[0] * 3, 1), order="F")
-        bigx = np.hstack(
-            (bigx, self.x[:, 3:6].reshape((self.x.shape[0] * 3, 1), order="F"))
-        )
-        reg = GM_KKP(
-            bigy, bigx, self.w, full_weights=False, name_y=["HR"], name_x=["RD", "PS"]
-        )
+        np.testing.assert_allclose(reg.betas,np.array([[ 6.49193589],
+ [ 3.55740165],
+ [ 1.29462748],
+ [ 0.4263399 ],
+ [22.47241979],
+ [45.82593532]]),RTOL)
+        np.testing.assert_allclose(reg.vm,np.array([[ 1.45113773e-02, -2.14882672e-06,  8.54997693e-05],
+ [-2.14882672e-06,  8.41929187e-03,  1.24553497e-03],
+ [ 8.54997693e-05,  1.24553497e-03,  8.12448812e-03]]),RTOL)
 
-        np.testing.assert_allclose(
-            reg.betas,
-            np.array(
-                [
-                    [6.49221562],
-                    [3.62445753],
-                    [1.31187779],
-                    [0.41777589],
-                    [22.81908224],
-                    [39.90993228],
-                ]
-            ),
-            RTOL,
-        )
-        np.testing.assert_allclose(
-            reg.vm,
-            np.array(
-                [
-                    [1.26948117e-02, -1.98160325e-06, 7.38157674e-05],
-                    [-1.98160325e-06, 7.69961725e-03, 1.13099329e-03],
-                    [7.38157674e-05, 1.13099329e-03, 7.26783636e-03],
-                ]
-            ),
-            RTOL,
-        )
-        np.testing.assert_equal(
-            reg.name_x, ["CONSTANT", "RD", "PS", "lambda", " sigma2_v", "sigma2_1"]
-        )
-        np.testing.assert_equal(reg.name_y, "HR")
+    def test_long_ident(self): 
+        bigy = self.y.reshape((self.y.size,1),order="F")
+        bigx = self.x[:,0:3].reshape((self.x.shape[0]*3,1),order='F')
+        bigx = np.hstack((bigx,self.x[:,3:6].reshape((self.x.shape[0]*3,1),order='F')))
+        reg = GM_KKP(bigy,bigx,self.w,full_weights=False,name_y=['HR'], name_x=['RD','PS'])
+
+        np.testing.assert_allclose(reg.betas,np.array([[ 6.49221562],
+ [ 3.62445753],
+ [ 1.31187779],
+ [ 0.41777589],
+ [22.81908224],
+ [39.90993228]]),RTOL)
+        np.testing.assert_allclose(reg.vm,np.array([[ 1.26948117e-02, -1.98160325e-06,  7.38157674e-05],
+ [-1.98160325e-06,  7.69961725e-03, 1.13099329e-03],
+ [ 7.38157674e-05,  1.13099329e-03,  7.26783636e-03]]),RTOL*10)
+        np.testing.assert_equal(reg.name_x,  ['CONSTANT', 'RD', 'PS', 'lambda', ' sigma2_v', 'sigma2_1'])
+        np.testing.assert_equal(reg.name_y,  'HR')
 
     def test_regimes(self):
         regimes = self.db.by_col("SOUTH")
-        reg = GM_KKP(
-            self.y,
-            self.x,
-            self.w,
-            full_weights=False,
-            regimes=regimes,
-            name_y=self.y_var0,
-            name_x=self.x_var0,
-        )
-        np.testing.assert_allclose(
-            reg.betas,
-            np.array(
-                [
-                    [5.25856482],
-                    [3.19249165],
-                    [1.0056967],
-                    [7.94560642],
-                    [3.13931041],
-                    [1.53700634],
-                    [0.35979407],
-                    [22.5650005],
-                    [39.71516708],
-                ]
-            ),
-            RTOL,
-        )
-        np.testing.assert_allclose(
-            np.sqrt(reg.vm.diagonal()),
-            np.array([0.158986, 0.157543, 0.104128, 0.165254, 0.117737, 0.136666]),
-            RTOL,
-        )
-        np.testing.assert_equal(
-            reg.name_x,
-            [
-                "0_CONSTANT",
-                "0_RD",
-                "0_PS",
-                "1_CONSTANT",
-                "1_RD",
-                "1_PS",
-                "lambda",
-                " sigma2_v",
-                "sigma2_1",
-            ],
-        )
-        np.testing.assert_equal(reg.name_y, "HR")
-        np.testing.assert_allclose(
-            reg.chow.regi,
-            np.array(
-                [
-                    [1.420430e02, 9.516507e-33],
-                    [7.311490e-02, 7.868543e-01],
-                    [9.652492e00, 1.890949e-03],
-                ]
-            ),
-            RTOL,
-        )
-        np.testing.assert_allclose(reg.chow.joint[0], 158.7225, RTOL)
+        reg = GM_KKP(self.y,self.x,self.w,full_weights=False,regimes=regimes,
+        name_y=self.y_var0, name_x=self.x_var0)
+        np.testing.assert_allclose(reg.betas,np.array([[ 5.25856482],
+ [ 3.19249165],
+ [ 1.0056967 ],
+ [ 7.94560642],
+ [ 3.13931041],
+ [ 1.53700634],
+ [ 0.35979407],
+ [22.5650005 ],
+ [39.71516708]]),RTOL)
+        np.testing.assert_allclose(np.sqrt(reg.vm.diagonal()),np.array([0.158986, 0.157543, 0.104128, 0.165254, 0.117737, 0.136666]),RTOL)
+        np.testing.assert_equal(reg.name_x,  ['0_CONSTANT', '0_RD', '0_PS', '1_CONSTANT', '1_RD', '1_PS', 'lambda', ' sigma2_v', 'sigma2_1'])
+        np.testing.assert_equal(reg.name_y,  'HR')
+        np.testing.assert_allclose(reg.chow.regi,np.array([[1.420430e+02, 9.516507e-33],
+       [7.311490e-02, 7.868543e-01],
+       [9.652492e+00, 1.890949e-03]]),RTOL*10)
+        np.testing.assert_allclose(reg.chow.joint[0],158.7225,RTOL)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()
+

--- a/spreg/tests/test_sur_error.py
+++ b/spreg/tests/test_sur_error.py
@@ -2,13 +2,15 @@ import unittest
 import numpy as np
 import libpysal
 from libpysal.examples import load_example
-from ..sur_utils import sur_dictxy
-from ..sur_error import SURerrorML, SURerrorGM
-from .test_sur import dict_compare
+from spreg.sur_utils import sur_dictxy
+from spreg.sur_error import SURerrorML, SURerrorGM
 from libpysal.common import RTOL
 
 ATOL = 0.0001
 
+def dict_compare(actual, desired, rtol, atol=1e-7):
+    for i in actual.keys():
+        np.testing.assert_allclose(actual[i], desired[i], rtol, atol=atol)
 
 class Test_SUR_error(unittest.TestCase):
     def setUp(self):
@@ -316,9 +318,7 @@ class Test_SUR_error_gm(unittest.TestCase):
     def setUp(self):
         nat = load_example("Natregimes")
         self.db = libpysal.io.open(nat.get_path("natregimes.dbf"), "r")
-        self.w = libpysal.weights.Queen.from_shapefile(
-            libpysal.examples.get_path("natregimes.shp")
-        )
+        self.w = libpysal.weights.Queen.from_shapefile(nat.get_path("natregimes.shp"))
         self.w.transform = "r"
 
     def test_error_gm(self):  # 2 equations

--- a/spreg/tests/test_twosls_sp_regimes.py
+++ b/spreg/tests/test_twosls_sp_regimes.py
@@ -22,7 +22,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         X.append(self.db.by_col("INC"))
         X.append(self.db.by_col("HOVAL"))
         self.X = np.array(X).T
-        reg = GM_Lag_Regimes(self.y, self.X, self.regimes, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False) 
+        reg = GM_Lag_Regimes(self.y, self.X, self.regimes, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False, robust=None)
         betas = np.array([[ 45.14892906],
        [ -1.42593383],
        [ -0.11501037],
@@ -121,7 +121,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
         q = np.reshape(q, (49,1))
-        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, lag_q=False, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False) 
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, lag_q=False, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False, robust=None)
         tbetas = np.array([[ 42.7266306 ],
        [ -0.15552345],
        [ 37.70545276],
@@ -162,7 +162,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
         q = np.reshape(q, (49,1))
-        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False) 
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, sig2n_k=True, regime_lag_sep=False, regime_err_sep=False, robust=None)
         tbetas = np.array([[ 37.87698329],
        [ -0.89426982],
        [ 31.4714777 ],
@@ -187,7 +187,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
         q = np.reshape(q, (49,1))
-        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, regime_lag_sep=False, regime_err_sep=False) 
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, regime_lag_sep=False, regime_err_sep=False, robust=None)
         tbetas = np.array([[ 37.87698329,  -0.89426982,  31.4714777 ,  -0.71640525,
          -0.28494432,  -0.2294271 ,   0.62996544]])
         np.testing.assert_allclose(tbetas, reg.betas.T,RTOL)
@@ -228,7 +228,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         w = libpysal.weights.util.lat2W(latt,latt)
         w.transform='r'
         regi = [0]*(n//2) + [1]*(n//2)
-        model = GM_Lag_Regimes(y, x1, regi, q=q, yend=x2, w=w, regime_lag_sep=True, regime_err_sep=True)
+        model = GM_Lag_Regimes(y, x1, regi, q=q, yend=x2, w=w, regime_lag_sep=True, regime_err_sep=True, robust=None)
         w1 = libpysal.weights.util.lat2W(latt//2,latt)
         w1.transform='r'
         model1 = GM_Lag(y[0:(n//2)].reshape((n//2),1), x1[0:(n//2)],yend=x2[0:(n//2)], q=q[0:(n//2)], w=w1)
@@ -244,7 +244,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
         q = np.reshape(q, (49,1))
-        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w,regime_lag_sep=True, regime_err_sep = True) 
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w,regime_lag_sep=True, regime_err_sep = True, robust=None)
         tbetas = np.array([[ 42.35827477],
        [ -0.09472413],
        [ -0.68794223],
@@ -287,7 +287,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         yd = np.reshape(yd, (49,1))
         q = np.array(self.db.by_col("DISCBD"))
         q = np.reshape(q, (49,1))
-        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, constant_regi='one', regime_lag_sep=False, regime_err_sep=False) 
+        reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, constant_regi='one', regime_lag_sep=False, regime_err_sep=False, robust=None)
         tbetas = np.array([[ -0.37658823],
        [ -0.9666079 ],
        [ 35.5445944 ],
@@ -328,7 +328,9 @@ class TestGMLag_Regimes(unittest.TestCase):
         q_var = ['DISCBD']
         q = np.array([self.db.by_col(name) for name in q_var]).T
         r_var = 'NSA'
-        reg = GM_Lag_Regimes(self.y, x, self.regimes, yend=yd, q=q, w=self.w, name_y=y_var, name_x=x_var, name_yend=yd_var, name_q=q_var, name_regimes=r_var, name_ds='columbus', name_w='columbus.gal', regime_lag_sep=False, regime_err_sep=False)
+        reg = GM_Lag_Regimes(self.y, x, self.regimes, yend=yd, q=q, w=self.w, name_y=y_var, name_x=x_var,
+                             name_yend=yd_var, name_q=q_var, name_regimes=r_var, name_ds='columbus',
+                             name_w='columbus.gal', regime_lag_sep=False, regime_err_sep=False, robust=None)
         betas = np.array([[ 37.87698329],
        [ -0.89426982],
        [ 31.4714777 ],
@@ -349,6 +351,64 @@ class TestGMLag_Regimes(unittest.TestCase):
         self.assertListEqual(reg.name_yend, ['0_HOVAL', '1_HOVAL', '_Global_W_CRIME'])
         self.assertListEqual(reg.name_q, ['0_DISCBD', '0_W_INC', '0_W_DISCBD', '1_DISCBD', '1_W_INC', '1_W_DISCBD'])
         self.assertEqual(reg.name_y, y_var)
+
+    def test_slx(self):
+        X = []
+        X.append(self.db.by_col("INC"))
+        X.append(self.db.by_col("HOVAL"))
+        self.X = np.array(X).T
+        reg = GM_Lag_Regimes(self.y, self.X, self.regimes, w=self.w, slx_lags=1, regime_lag_sep=False,
+                             regime_err_sep=False, spat_diag=True)
+        betas = np.array([[ 8.18931398e+01],
+                         [-1.53395435e+00],
+                         [-1.69757478e-01],
+                         [-2.27789212e+00],
+                         [ 5.39079719e-01],
+                         [ 7.51699174e+01],
+                         [-1.08739064e+00],
+                         [-2.83520279e-01],
+                         [-1.68207712e+00],
+                         [ 2.74687447e-01],
+                         [-3.46101374e-02]])
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
+        vm = np.array( [[ 1.73599745e+03, -9.34710692e+00, -1.24643977e+00, -6.47037384e+01,
+                           7.12544407e+00,  1.67217894e+03, -3.05066669e+00, -2.35566285e+00,
+                          -3.66089456e+01, -4.16736383e+00, -2.36649704e+01],
+                         [-9.34710692e+00,  2.76627235e-01, -4.82833143e-02,  8.93797856e-02,
+                           3.01134955e-02, -9.78627573e+00,  2.41397355e-02,  1.18016819e-02,
+                           2.19536352e-01,  2.40036703e-02,  1.36868186e-01],
+                         [-1.24643977e+00, -4.82833143e-02,  2.49271317e-02,  1.08816895e-01,
+                          -3.05204771e-02, -8.06738318e-01,  6.26670530e-04,  1.40330458e-03,
+                           1.69512409e-02,  2.06235513e-03,  1.16361002e-02],
+                         [-6.47037384e+01,  8.93797856e-02,  1.08816895e-01,  3.37057241e+00,
+                          -6.18148061e-01, -6.02788288e+01,  1.07776025e-01,  8.56099990e-02,
+                           1.31783651e+00,  1.50360008e-01,  8.53645284e-01],
+                         [ 7.12544407e+00,  3.01134955e-02, -3.05204771e-02, -6.18148061e-01,
+                           1.79091963e-01,  6.63593281e+00, -1.64138641e-02, -7.98832541e-03,
+                          -1.48902330e-01, -1.62737808e-02, -9.27966724e-02],
+                         [ 1.67217894e+03, -9.78627573e+00, -8.06738318e-01, -6.02788288e+01,
+                           6.63593281e+00,  1.77071537e+03, -7.45841412e+00, -1.64359023e+00,
+                          -3.92564157e+01, -4.79661230e+00, -2.37950208e+01],
+                         [-3.05066669e+00,  2.41397355e-02,  6.26670530e-04,  1.07776025e-01,
+                          -1.64138641e-02, -7.45841412e+00,  4.80396971e-01, -9.88376849e-02,
+                           8.60302399e-02,  4.92161147e-02,  4.74983701e-02],
+                         [-2.35566285e+00,  1.18016819e-02,  1.40330458e-03,  8.56099990e-02,
+                          -7.98832541e-03, -1.64359023e+00, -9.88376849e-02,  4.80027099e-02,
+                          -2.23775047e-02,  6.77837002e-03,  3.22304374e-02],
+                         [-3.66089456e+01,  2.19536352e-01,  1.69512409e-02,  1.31783651e+00,
+                          -1.48902330e-01, -3.92564157e+01,  8.60302399e-02, -2.23775047e-02,
+                           1.50194231e+00, -1.84011183e-02,  5.24380589e-01],
+                         [-4.16736383e+00,  2.40036703e-02,  2.06235513e-03,  1.50360008e-01,
+                          -1.62737808e-02, -4.79661230e+00,  4.92161147e-02,  6.77837002e-03,
+                          -1.84011183e-02,  4.72613924e-02,  5.90507313e-02],
+                         [-2.36649704e+01,  1.36868186e-01,  1.16361002e-02,  8.53645284e-01,
+                          -9.27966724e-02, -2.37950208e+01,  4.74983701e-02,  3.22304374e-02,
+                           5.24380589e-01,  5.90507313e-02,  3.35692100e-01]])
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
+        ak_test = np.array([0.528338, 0.467306])
+        np.testing.assert_allclose(reg.ak_test, ak_test,RTOL)
+        cfh_test = np.array([8.094023, 0.088194])
+        np.testing.assert_allclose(reg.cfh_test, cfh_test,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/spreg/twosls.py
+++ b/spreg/twosls.py
@@ -159,7 +159,6 @@ class BaseTSLS(RegressionPropsY, RegressionPropsVM):
         hthi = la.inv(hth)
         zth = spdot(z.T, h)
         hty = spdot(h.T, y)
-
         factor_1 = np.dot(zth, hthi)
         factor_2 = np.dot(factor_1, zth.T)
         # this one needs to be in cache to be used in AK

--- a/spreg/twosls_regimes.py
+++ b/spreg/twosls_regimes.py
@@ -353,7 +353,7 @@ class TSLS_Regimes(BaseTSLS, REGI.Regimes_Frame):
         vm=False,
         constant_regi="many",
         cols2regi="all",
-        regime_err_sep=True,
+        regime_err_sep=False,
         name_y=None,
         name_x=None,
         cores=False,

--- a/spreg/user_output.py
+++ b/spreg/user_output.py
@@ -189,12 +189,29 @@ def set_name_q_sp(name_x, w_lags, name_q, lag_q, force_all=False):
     if lag_q:
         names = names + name_q
     sp_inst_names = []
-    for j in names:
-        sp_inst_names.append("W_" + j)
-    if w_lags > 1:
-        for i in range(2, w_lags + 1):
-            for j in names:
-                sp_inst_names.append("W" + str(i) + "_" + j)
+    existing_names = set(names)
+    name_count = {} # Dictionary to store the count of each name
+
+    for name in names:
+        if not name.startswith("W_"):
+            name_count[name] = 2
+        else:
+            if name[2:] not in name_count:
+                name_count[name[2:]] = 2
+
+    for i in range(w_lags):
+        for name in names:
+            if name.startswith("W_"):
+                lag_name = f"W{name_count[name[2:]]}_{name[2:]}"
+                name_count[name[2:]] += 1
+            else:
+                if ("W_" + name) not in existing_names:
+                    lag_name = f"W_{name}"
+                else:
+                    lag_name = f"W{name_count[name]}_{name}"
+                    name_count[name] += 1
+            sp_inst_names.append(lag_name)
+            existing_names.add(lag_name)
     return sp_inst_names
 
 

--- a/spreg/utils.py
+++ b/spreg/utils.py
@@ -322,7 +322,7 @@ def _moments2eqs(A1, s, u):
     return [G, g]
 
 
-def optim_moments(moments_in, vcX=np.array([0]), all_par=False, start=None):
+def optim_moments(moments_in, vcX=np.array([0]), all_par=False, start=None, hard_bound=False):
     """
     Optimization of moments
     ...
@@ -341,7 +341,10 @@ def optim_moments(moments_in, vcX=np.array([0]), all_par=False, start=None):
                   solution or just the 1st. Default is 1st only.
     start       : list
                   List with initial values for the optimization
-
+    hard_bound   : boolean
+                   If true, raises an exception if the estimated spatial
+                   autoregressive parameter is outside the maximum/minimum bounds.
+                   
     Returns
     -------
     x, f, d     : tuple
@@ -385,6 +388,10 @@ def optim_moments(moments_in, vcX=np.array([0]), all_par=False, start=None):
             start = [0.0, 1.0, 1.0]
         bounds = [(-0.99, 0.99), (0.0, None), (0.0, None)]
     lambdaX = op.fmin_l_bfgs_b(optim_par, start, approx_grad=True, bounds=bounds)
+
+    if hard_bound:
+        if abs(lambdaX[0][0]) >= 0.99:
+            raise Exception("Spatial parameter was outside the bounds of -0.99 and 0.99")
 
     if all_par:
         return lambdaX[0]


### PR DESCRIPTION
### **Version 1.5**

This new version of pysal/spreg brings several new features, performance enhancements and bug fixes. The main contributors to this new version are Luc Anselin, Pedro Amaral, Renan Serenini and Lisa Singh.

**Updates:**

1-	Introduction of the DGP module

- 	The DGP module allows for the creation of spatial models for specific Data Generation Processes (DGP) to support simulation exercises. These include the creation of error term vectors (classic and spatial), dependent and independent variables, spatially correlated or not, and other elements for OLS, SAR, SLX, SDM, SARAR models, etc.

2-	Introduction of new specification tests
- 	The Koley-Bera (2024) tests for WX and SDM, and their variants, have been included to the diagnostics suite.
- 	The Common Factor Hypothesis test has been added to Spatial Durbin Models (GM and ML).
 
3-	Impact estimation
- 	The estimation of average direct impact (ADI), average indirect impact (AII), and average total impact (ATI) in summary results has been added to models with a spatial lag of the dependent variable.

4-	Endogenous Spatial Regimes estimation
- 	Methods for endogenous spatial regimes estimation based on Anselin and Amaral (2023) have been added, such as OLS_Endog_Regimes and GM_Lag_Endog_Regimes.

5-	A flag to allow for the printing of the table with the coefficients' results and their inference straight in LaTeX format 

6-	Skater_reg now allows for the estimation of Spatial Lag models with a common spatial lag across regimes. A method adapted from Mojena (1977)'s Rule Two has also been introduced to find the optimal number of regimes for the endogenous spatial regimes models.

7-	Several minor performance enhancements and bug fixes.
