### PR TITLE
SciPy sparse array migration from sparse matrices

### DIFF
--- a/spreg/diagnostics_probit.py
+++ b/spreg/diagnostics_probit.py
@@ -264,28 +264,28 @@ def sp_tests(regprob=None, obj_list=None):
     elif obj_list:
         w, fittedvalues, u_naive, u_gen = obj_list
         Phi = norm.cdf(fittedvalues)
-        phi = norm.pdf(fittedvalues)        
+        phi = norm.pdf(fittedvalues)
         n = w.n
 
     try:
         w = w.sparse
     except:
-        w = w    
+        w = w
         
     # Pinkse_error:
     Phi_prod = Phi * (1 - Phi)
     sig2 = np.sum((phi * phi) / Phi_prod) / n
-    LM_err_num = np.dot(u_gen.T, (w * u_gen)) ** 2
-    trWW = np.sum((w * w).diagonal())
-    trWWWWp = trWW + np.sum((w * w.T).diagonal())
+    LM_err_num = np.dot(u_gen.T, (w @ u_gen)) ** 2
+    trWW = np.sum((w @ w).diagonal())
+    trWWWWp = trWW + np.sum((w @ w.T).diagonal())
     LM_err = float(1.0 * LM_err_num / (sig2 ** 2 * trWWWWp))
     LM_err = np.array([LM_err, stats.chisqprob(LM_err, 1)])
     # KP_error:
     moran = moran_KP(w, u_naive, Phi_prod)
     # Pinkse-Slade_error:
     u_std = u_naive / np.sqrt(Phi_prod)
-    ps_num = np.dot(u_std.T, (w * u_std)) ** 2
-    trWpW = np.sum((w.T * w).diagonal())
+    ps_num = np.dot(u_std.T, (w @ u_std)) ** 2
+    trWpW = np.sum((w.T @ w).diagonal())
     ps = float(ps_num / (trWW + trWpW))
     # chi-square instead of bootstrap.
     ps = np.array([ps, stats.chisqprob(ps, 1)])
@@ -322,12 +322,12 @@ def moran_KP(w, u, sig2i):
         w = w.sparse
     except:
         pass
-    moran_num = np.dot(u.T, (w * u))
-    E = SP.lil_matrix(w.get_shape())
+    moran_num = np.dot(u.T, (w @ u))
+    E = SP.lil_matrix(w.shape)
     E.setdiag(sig2i.flat)
     E = E.asformat("csr")
-    WE = w * E
-    moran_den = np.sqrt(np.sum((WE * WE + (w.T * E) * WE).diagonal()))
+    WE = w @ E
+    moran_den = np.sqrt(np.sum((WE @ WE + (w.T @ E) @ WE).diagonal()))
     moran = float(1.0 * moran_num / moran_den)
     moran = np.array([moran, stats.norm.sf(abs(moran)) * 2.0])
     return moran

--- a/spreg/diagnostics_sp.py
+++ b/spreg/diagnostics_sp.py
@@ -483,7 +483,7 @@ class spDcache:
     @property
     def j(self):
         if "j" not in self._cache:
-            wxb = self.w.sparse * self.reg.predy
+            wxb = self.w.sparse @ self.reg.predy
             wxb2 = np.dot(wxb.T, wxb)
             xwxb = spdot(self.reg.x.T, wxb)
             num1 = wxb2 - np.dot(xwxb.T, np.dot(self.reg.xtxi, xwxb))
@@ -495,7 +495,7 @@ class spDcache:
     @property
     def wu(self):
         if "wu" not in self._cache:
-            self._cache["wu"] = self.w.sparse * self.reg.u
+            self._cache["wu"] = self.w.sparse @ self.reg.u
         return self._cache["wu"]
 
     @property
@@ -508,14 +508,14 @@ class spDcache:
     @property
     def utwyDs(self):
         if "utwyDs" not in self._cache:
-            res = np.dot(self.reg.u.T, self.w.sparse * self.reg.y)
+            res = np.dot(self.reg.u.T, self.w.sparse @ self.reg.y)
             self._cache["utwyDs"] = res / self.reg.sig2n
         return self._cache["utwyDs"]
 
     @property
     def t(self):
         if "t" not in self._cache:
-            prod = (self.w.sparse.T + self.w.sparse) * self.w.sparse
+            prod = (self.w.sparse.T + self.w.sparse) @ self.w.sparse
             self._cache["t"] = np.sum(prod.diagonal())
         return self._cache["t"]
 
@@ -703,7 +703,7 @@ def lm_wx(reg, w):
     except KeyError:
         xx = reg.x[:, reg._var_type == 'x']
     # WX
-    wx = w.sparse * xx
+    wx = w.sparse @ xx
     # end of preliminaries
     # X'W'u
     xtwtu = wx.T @ reg.u
@@ -748,13 +748,13 @@ def lm_spdurbin(reg,w):
         xx = reg.x[:, reg._var_type == 'x']
     k = x1.shape[1]
     # WX
-    wx = w.sparse * xx
+    wx = w.sparse @ xx
     # X1b
     xb = reg.predy
     # WX1b
-    wxb = w.sparse * xb
+    wxb = w.sparse @ xb
     # Wy
-    wy = w.sparse * reg.y
+    wy = w.sparse @ reg.y
     # y'W'e / sig2n
     drho = (wy.T @ reg.u) / reg.sig2n
     # X'W'e / sign2n

--- a/spreg/diagnostics_sur.py
+++ b/spreg/diagnostics_sur.py
@@ -160,7 +160,7 @@ def surLMe(n_eq, WS, bigE, sig):
 
     """
     # spatially lagged residuals
-    WbigE = WS * bigE
+    WbigE = WS @ bigE
     # score
     EWE = np.dot(bigE.T, WbigE)
     sigi = la.inv(sig)
@@ -173,9 +173,9 @@ def surLMe(n_eq, WS, bigE, sig):
     score.resize(1, n_eq)
 
     # trace terms
-    WW = WS * WS
+    WW = WS @ WS
     trWW = np.sum(WW.diagonal())
-    WTW = WS.T * WS
+    WTW = WS.T @ WS
     trWtW = np.sum(WTW.diagonal())
     # denominator
     SiS = sigi * sig
@@ -222,18 +222,18 @@ def surLMlag(n_eq, WS, bigy, bigX, bigE, bigYP, sig, varb):
     """
     # Score
     Y = np.hstack([bigy[r] for r in range(n_eq)])
-    WY = WS * Y
+    WY = WS @ Y
     EWY = np.dot(bigE.T, WY)
     sigi = la.inv(sig)
-    SEWE = sigi * EWY
+    SEWE = sigi @ EWY
     score = SEWE.sum(axis=0)  # column sums
     score.resize(1, n_eq)  # score as a row vector
 
     # I(rho,rho) as partitioned inverse, eq 72
     # trace terms
-    WW = WS * WS
+    WW = WS @ WS
     trWW = np.sum(WW.diagonal())  # T1
-    WTW = WS.T * WS
+    WTW = WS.T @ WS
     trWtW = np.sum(WTW.diagonal())  # T2
 
     # I(rho,rho)
@@ -241,7 +241,7 @@ def surLMlag(n_eq, WS, bigy, bigX, bigE, bigYP, sig, varb):
     Tii = trWW * np.identity(n_eq)  # T1It
     tSiS = trWtW * SiS
     firstHalf = Tii + tSiS
-    WbigYP = WS * bigYP
+    WbigYP = WS @ bigYP
     inner = np.dot(WbigYP.T, WbigYP)
     secondHalf = sigi * inner
     Ipp = firstHalf + secondHalf  # eq. 75

--- a/spreg/error_sp.py
+++ b/spreg/error_sp.py
@@ -112,7 +112,7 @@ class BaseGM_Error(RegressionPropsY):
         self.u = y - self.predy
         self.betas = np.vstack((ols2.betas, np.array([[lambda1]])))
         self.sig2 = ols2.sig2n
-        self.e_filtered = self.u - lambda1 * w * self.u
+        self.e_filtered = self.u - lambda1 * w @ self.u
 
         self.vm = self.sig2 * ols2.xtxi
         se_betas = np.sqrt(self.vm.diagonal())
@@ -435,8 +435,8 @@ class BaseGM_Endog_Error(RegressionPropsY):
         self.betas = np.vstack((tsls2.betas, np.array([[lambda1]])))
         self.predy = spdot(tsls.z, tsls2.betas)
         self.u = y - self.predy
-        self.sig2 = float(np.dot(tsls2.u.T, tsls2.u)) / self.n
-        self.e_filtered = self.u - lambda1 * w * self.u
+        self.sig2 = float(np.dot(tsls2.u.T, tsls2.u).squeeze()) / self.n
+        self.e_filtered = self.u - lambda1 * w @ self.u
         self.vm = self.sig2 * tsls2.varb
         self._cache = {}
 
@@ -1384,14 +1384,14 @@ def _momentsGM_Error(w, u):
         wsparse = w
     n = wsparse.shape[0]
     u2 = np.dot(u.T, u)
-    wu = wsparse * u
+    wu = wsparse @ u
     uwu = np.dot(u.T, wu)
     wu2 = np.dot(wu.T, wu)
-    wwu = wsparse * wu
+    wwu = wsparse @ wu
     uwwu = np.dot(u.T, wwu)
     wwu2 = np.dot(wwu.T, wwu)
     wuwwu = np.dot(wu.T, wwu)
-    wtw = wsparse.T * wsparse
+    wtw = wsparse.T @ wsparse
     trWtW = np.sum(wtw.diagonal())
     g = np.array([[u2[0][0], wu2[0][0], uwu[0][0]]]).T / n
     G = (

--- a/spreg/error_sp_hom.py
+++ b/spreg/error_sp_hom.py
@@ -162,7 +162,7 @@ class BaseGM_Error_Hom(RegressionPropsY):
         # Output
         self.betas = np.vstack((ols_s.betas, lambda2))
         self.vm, self.sig2 = get_omega_hom_ols(w, wA1, wA2, self, lambda2, moments[0])
-        self.e_filtered = self.u - lambda2 * w * self.u
+        self.e_filtered = self.u - lambda2 * w @ self.u
         self._cache = {}
 
 
@@ -594,7 +594,7 @@ class BaseGM_Endog_Error_Hom(RegressionPropsY):
         # Output
         self.betas = np.vstack((tsls_s.betas, lambda2))
         self.vm, self.sig2 = get_omega_hom(w, wA1, wA2, self, lambda2, moments[0])
-        self.e_filtered = self.u - lambda2 * w * self.u
+        self.e_filtered = self.u - lambda2 * w @ self.u
         self._cache = {}
 
 
@@ -1526,18 +1526,18 @@ def moments_hom(w, wA1, wA2, u):
 
     """
     n = w.shape[0]
-    A1u = wA1 * u
-    A2u = wA2 * u
-    wu = w * u
+    A1u = wA1 @ u
+    A2u = wA2 @ u
+    wu = w @ u
 
     g1 = np.dot(u.T, A1u)
     g2 = np.dot(u.T, A2u)
     g = np.array([[g1][0][0], [g2][0][0]]) / n
 
-    G11 = 2 * np.dot(wu.T * wA1, u)
-    G12 = -np.dot(wu.T * wA1, wu)
-    G21 = 2 * np.dot(wu.T * wA2, u)
-    G22 = -np.dot(wu.T * wA2, wu)
+    G11 = 2 * np.dot(wu.T @ wA1, u)
+    G12 = -np.dot(wu.T @ wA1, wu)
+    G21 = 2 * np.dot(wu.T @ wA2, u)
+    G22 = -np.dot(wu.T @ wA2, wu)
     G = np.array([[G11[0][0], G12[0][0]], [G21[0][0], G22[0][0]]]) / n
     return [G, g]
 
@@ -1582,11 +1582,11 @@ def get_vc_hom(w, wA1, wA2, reg, lambdapar, z_s=None, for_omegaOLS=False):
     mu3 = np.sum(u_s**3) / n
     mu4 = np.sum(u_s**4) / n
 
-    tr11 = wA1 * wA1
+    tr11 = wA1 @ wA1
     tr11 = np.sum(tr11.diagonal())
-    tr12 = wA1 * (wA2 * 2)
+    tr12 = wA1 @ (wA2 * 2)
     tr12 = np.sum(tr12.diagonal())
-    tr22 = wA2 * wA2 * 2
+    tr22 = wA2 @ wA2 * 2
     tr22 = np.sum(tr22.diagonal())
     vecd1 = np.array([wA1.diagonal()]).T
 
@@ -1605,8 +1605,8 @@ def get_vc_hom(w, wA1, wA2, reg, lambdapar, z_s=None, for_omegaOLS=False):
         or issubclass(type(z_s), SP.csr.csr_matrix)
         or issubclass(type(z_s), SP.csc.csc_matrix)
     ):
-        alpha1 = (-2 / n) * spdot(z_s.T, wA1 * u_s)
-        alpha2 = (-2 / n) * spdot(z_s.T, wA2 * u_s)
+        alpha1 = (-2 / n) * spdot(z_s.T, wA1 @ u_s)
+        alpha2 = (-2 / n) * spdot(z_s.T, wA2 @ u_s)
 
         hth = spdot(reg.h.T, reg.h)
         hthni = la.inv(hth / n)

--- a/spreg/sputils.py
+++ b/spreg/sputils.py
@@ -36,7 +36,7 @@ def spdot(a, b, array_out=True):
         or type(a).__name__ == "csc_matrix"
         or type(b).__name__ == "csc_matrix"
     ):
-        ab = a * b
+        ab = a @ b
         if array_out:
             if type(ab).__name__ == "csc_matrix" or type(ab).__name__ == "csr_matrix":
                 ab = ab.toarray()
@@ -147,7 +147,7 @@ def spbroadcast(a, b, array_out=False):
     elif type(a).__name__ == "csr_matrix":
         b_mod = SP.lil_matrix((b.shape[0], b.shape[0]))
         b_mod.setdiag(b)
-        ab = (a.T * b_mod).T
+        ab = (a.T @ b_mod).T
         if array_out:
             if type(ab).__name__ == "csr_matrix":
                 ab = ab.toarray()

--- a/spreg/sur_error.py
+++ b/spreg/sur_error.py
@@ -109,16 +109,16 @@ class BaseSURerrorGM:
         # spatially lagged variables
         self.bigylag = {}
         for r in range(self.n_eq):
-            self.bigylag[r] = WS * self.bigy[r]
+            self.bigylag[r] = WS @ self.bigy[r]
         # note: unlike WX as instruments, this includes the constant
         self.bigXlag = {}
         for r in range(self.n_eq):
-            self.bigXlag[r] = WS * self.bigX[r]
+            self.bigXlag[r] = WS @ self.bigX[r]
 
         # spatially filtered variables
         sply = filter_dict(lam, self.bigy, self.bigylag)
         splX = filter_dict(lam, self.bigX, self.bigXlag)
-        WbigE = WS * reg0.olsE
+        WbigE = WS @ reg0.olsE
         splbigE = reg0.olsE - WbigE * lam.T
         splXX, splXy = sur_crossprod(splX, sply)
         b1, varb1, sig1 = sur_est(splXX, splXy, splbigE, self.bigK)
@@ -135,10 +135,10 @@ class BaseSURerrorGM:
 def _momentsGM_sur_Error(w, u):
     n = w.shape[0]
     u2 = (u * u).sum(0)
-    wu = w * u
+    wu = w @ u
     uwu = (u * wu).sum(0)
     wu2 = (wu * wu).sum(0)
-    wwu = w * wu
+    wwu = w @ wu
     uwwu = (u * wwu).sum(0)
     wwu2 = (wwu * wwu).sum(0)
     wwuwu = (wwu * wu).sum(0)
@@ -500,11 +500,11 @@ class BaseSURerrorML:
         # spatially lagged variables
         self.bigylag = {}
         for r in range(self.n_eq):
-            self.bigylag[r] = WS * self.bigy[r]
+            self.bigylag[r] = WS @ self.bigy[r]
         # note: unlike WX as instruments, this includes the constant
         self.bigXlag = {}
         for r in range(self.n_eq):
-            self.bigXlag[r] = WS * self.bigX[r]
+            self.bigXlag[r] = WS @ self.bigX[r]
 
         # spatial parameter starting values
         lam = np.zeros((self.n_eq, 1))  # initialize as an array
@@ -544,7 +544,7 @@ class BaseSURerrorML:
             fun0 = fun1
             sply = filter_dict(lam, self.bigy, self.bigylag)
             splX = filter_dict(lam, self.bigX, self.bigXlag)
-            WbigE = WS * bigE
+            WbigE = WS @ bigE
             splbigE = bigE - WbigE * lam.T
             splXX, splXy = sur_crossprod(splX, sply)
             b1, varb1, sig1 = sur_est(splXX, splXy, splbigE, self.bigK)
@@ -964,7 +964,7 @@ def clik(lam, n, n2, n_eq, bigE, I, WS):
                   log-likelihood function
 
     """
-    WbigE = WS * bigE
+    WbigE = WS @ bigE
     spfbigE = bigE - WbigE * lam.T
     sig = np.dot(spfbigE.T, spfbigE) / n
     ldet = la.slogdet(sig)[1]
@@ -1018,7 +1018,7 @@ def surerrvm(n, n_eq, w, lam, sig):
         B = I - lamWS
         bb = B.todense()
         Bi = la.inv(bb)
-        D = WS * Bi
+        D = WS @ Bi
         trDi[i] = np.trace(D)
         DD = np.dot(D, D)
         trDDi[i] = np.trace(DD)
@@ -1030,7 +1030,7 @@ def surerrvm(n, n_eq, w, lam, sig):
             B = I - lamWS
             bb = B.todense()
             Bi = la.inv(bb)
-            Dj = WS * Bi
+            Dj = WS @ Bi
             DD = np.dot(D.T, Dj)
             trDTiDj[i, j] = np.trace(DD)
             trDTiDj[j, i] = trDTiDj[i, j]

--- a/spreg/sur_lag.py
+++ b/spreg/sur_lag.py
@@ -367,13 +367,13 @@ class SURlagIV(BaseThreeSLS, REGI.Regimes_Frame):
         wxnames = {}
         if w_lags == 1:
             for r in range(self.n_eq):
-                bigwx[r] = WS * bigX[r][:, 1:]
+                bigwx[r] = WS @ bigX[r][:, 1:]
                 wxnames[r] = ["W_" + i for i in self.name_bigX[r][1:]]
             if bigq:  # other instruments
                 if lag_q:  # also lags for instruments
                     bigwq = {}
                     for r in range(self.n_eq):
-                        bigwq = WS * bigq[r]
+                        bigwq = WS @ bigq[r]
                         bigq[r] = np.hstack((bigq[r], bigwx[r], bigwq))
                         wqnames = ["W_" + i for i in self.name_bigq[r]]
                         wxnames[r] = wxnames[r] + wqnames
@@ -389,12 +389,12 @@ class SURlagIV(BaseThreeSLS, REGI.Regimes_Frame):
                     self.name_bigq[r] = wxnames[r]
         elif w_lags > 1:  # higher order lags for WX
             for r in range(self.n_eq):
-                bigwxwork = WS * bigX[r][:, 1:]
+                bigwxwork = WS @ bigX[r][:, 1:]
                 bigwx[r] = bigwxwork
                 nameswork = ["W_" + i for i in self.name_bigX[r][1:]]
                 wxnames[r] = nameswork
                 for i in range(1, w_lags):
-                    bigwxwork = WS * bigwxwork
+                    bigwxwork = WS @ bigwxwork
                     bigwx[r] = np.hstack((bigwx[r], bigwxwork))
                     nameswork = ["W" + i for i in nameswork]
                     wxnames[r] = wxnames[r] + nameswork
@@ -403,12 +403,12 @@ class SURlagIV(BaseThreeSLS, REGI.Regimes_Frame):
                     wq = {}
                     wqnames = {}
                     for r in range(self.n_eq):
-                        bigwq = WS * bigq[r]
+                        bigwq = WS @ bigq[r]
                         wqnameswork = ["W_" + i for i in self.name_bigq[r]]
                         wqnames[r] = wqnameswork
                         wq[r] = bigwq
                         for i in range(1, w_lags):
-                            bigwq = WS * bigwq
+                            bigwq = WS @ bigwq
                             wq[r] = np.hstack((wq[r], bigwq))
                             wqnameswork = ["W" + i for i in wqnameswork]
                             wqnames[r] = wqnames[r] + wqnameswork
@@ -481,7 +481,7 @@ class SURlagIV(BaseThreeSLS, REGI.Regimes_Frame):
 def _get_spatial_lag(reg, bigyend, WS, name_bigyend):
     bigylag = {}
     for r in range(reg.n_eq):
-        bigylag[r] = WS * reg.bigy[r]
+        bigylag[r] = WS @ reg.bigy[r]
     if bigyend is not None:
         for r in range(reg.n_eq):
             bigyend[r] = np.hstack((bigyend[r], bigylag[r]))

--- a/spreg/tests/test_twosls_regimes.py
+++ b/spreg/tests/test_twosls_regimes.py
@@ -29,7 +29,7 @@ class TestTSLS(unittest.TestCase):
         betas = np.array([[ 80.23408166],[  5.48218125],[ 82.98396737],[  0.49775429],[ -3.72663211],[ -1.27451485]])
         np.testing.assert_allclose(reg.betas, betas,RTOL)
         h_0 = np.array([[  0.   ,   0.   ,   1.   ,  19.531,   0.   ,   5.03 ]])
-        np.testing.assert_allclose(reg.h[0]*np.eye(6), h_0, RTOL)
+        np.testing.assert_allclose(reg.h[0] @ np.eye(6), h_0, RTOL)
         hth = np.array([[   25.        ,   416.378999  ,     0.        ,     0.        ,\
            76.03      ,     0.        ],\
        [  416.378999  ,  7831.05477839,     0.        ,     0.        ,\
@@ -79,7 +79,7 @@ class TestTSLS(unittest.TestCase):
         predy_5 = np.array([[ -9.85078372],[ 36.75098196],[ 57.34266859],[ 42.89851907],[ 58.9840913 ]]) 
         np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         q_5 = np.array([ 5.03,  4.27,  3.89,  3.7 ,  2.83])
-        np.testing.assert_array_equal((reg.q[0:5].T*np.eye(5))[1,:], q_5)
+        np.testing.assert_array_equal((reg.q[0:5].T @ np.eye(5))[1,:], q_5)
         np.testing.assert_allclose(reg.sig2n_k, 990.00750983736714,RTOL)
         np.testing.assert_allclose(reg.sig2n, 868.78210046952631,RTOL)
         np.testing.assert_allclose(reg.sig2, 990.00750983736714,RTOL)
@@ -114,13 +114,13 @@ class TestTSLS(unittest.TestCase):
            0.        ,    1.3154267 ]]) 
         np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
-        np.testing.assert_allclose(reg.x[0]*np.eye(4), x_0,RTOL)
+        np.testing.assert_allclose(reg.x[0] @ np.eye(4), x_0,RTOL)
         y_5 = np.array([[ 15.72598 ], [ 18.801754], [ 30.626781], [ 32.38776 ], [ 50.73151 ]]) 
         np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_3 = np.array([[  0.      ,  80.467003],[  0.      ,  44.567001],[  0.      ,  26.35    ]]) 
-        np.testing.assert_allclose(reg.yend[0:3]*np.eye(2), yend_3,RTOL)
+        np.testing.assert_allclose(reg.yend[0:3] @ np.eye(2), yend_3,RTOL)
         z_0 = np.array([[  0.      ,   0.      ,   1.      ,  19.531   ,   0.      , 80.467003]]) 
-        np.testing.assert_allclose(reg.z[0]*np.eye(6), z_0,RTOL)
+        np.testing.assert_allclose(reg.z[0] @ np.eye(6), z_0,RTOL)
         zthhthi = np.array([[  1.00000000e+00,   0.00000000e+00,   0.00000000e+00,\
           0.00000000e+00,  -4.44089210e-16,   0.00000000e+00],\
        [ -1.24344979e-14,   1.00000000e+00,   0.00000000e+00,\

--- a/spreg/tests/test_twosls_sp_regimes.py
+++ b/spreg/tests/test_twosls_sp_regimes.py
@@ -39,7 +39,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         np.testing.assert_allclose(reg.e_pred[0:5], e_5,RTOL)
         h_0 = np.array([[  0.       ,   0.       ,   0.       ,   1.       ,  19.531    ,
          80.467003 ,   0.       ,   0.       ,  18.594    ,  35.4585005]])
-        np.testing.assert_allclose(reg.h[0]*np.eye(10), h_0)
+        np.testing.assert_allclose(reg.h[0] @ np.eye(10), h_0)
         self.assertEqual(reg.k, 7)
         self.assertEqual(reg.kstar, 1)
         np.testing.assert_allclose(reg.mean_y, 35.128823897959187,RTOL)
@@ -62,7 +62,7 @@ class TestGMLag_Regimes(unittest.TestCase):
        [ 45.4790797 ]])
         np.testing.assert_allclose(reg.predy_e[0:5], predy_e_5,RTOL)
         q_5 = np.array([[  0.       ,   0.       ,  18.594    ,  35.4585005]])
-        np.testing.assert_allclose(reg.q[0]*np.eye(4), q_5, RTOL)
+        np.testing.assert_allclose(reg.q[0] @ np.eye(4), q_5, RTOL)
         self.assertEqual(reg.robust, 'unadjusted')
         np.testing.assert_allclose(reg.sig2n_k, 109.76462904625834,RTOL)
         np.testing.assert_allclose(reg.sig2n, 94.08396775393571,RTOL)
@@ -85,7 +85,7 @@ class TestGMLag_Regimes(unittest.TestCase):
         np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         x_0 = np.array([[  0.      ,   0.      ,   0.      ,   1.      ,  19.531   ,
          80.467003]])
-        np.testing.assert_allclose(reg.x[0]*np.eye(6), x_0,RTOL)
+        np.testing.assert_allclose(reg.x[0] @ np.eye(6), x_0,RTOL)
         y_5 = np.array([[ 15.72598 ],
        [ 18.801754],
        [ 30.626781],
@@ -97,10 +97,10 @@ class TestGMLag_Regimes(unittest.TestCase):
        [ 29.411751  ],
        [ 34.64647575],
        [ 40.4653275 ]])
-        np.testing.assert_allclose(reg.yend[0:5]*np.array([[1]]), yend_5,RTOL)
+        np.testing.assert_allclose(reg.yend[0:5] @ np.array([[1]]), yend_5,RTOL)
         z_0 = np.array([[  0.       ,   0.       ,   0.       ,   1.       ,  19.531    ,
          80.467003 ,  24.7142675]]) 
-        np.testing.assert_allclose(reg.z[0]*np.eye(7), z_0,RTOL)
+        np.testing.assert_allclose(reg.z[0] @ np.eye(7), z_0,RTOL)
         zthhthi = np.array([  1.00000000e+00,  -2.35922393e-16,   5.55111512e-17,
          0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
         -4.44089210e-16,   2.22044605e-16,   0.00000000e+00,

--- a/spreg/user_output.py
+++ b/spreg/user_output.py
@@ -15,10 +15,10 @@ from . import sputils as spu
 from libpysal import weights
 from libpysal import graph
 import scipy
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 from scipy.sparse import issparse
-from .utils import get_lags        
-from itertools import compress    
+from .utils import get_lags
+from itertools import compress
 
 
 def set_name_ds(name_ds):

--- a/spreg/utils.py
+++ b/spreg/utils.py
@@ -214,9 +214,8 @@ def get_A1_het(S):
                       A1 matrix in scipy sparse format
 
     """
-    StS = S.T * S
-    d = SP.spdiags([StS.diagonal()], [0], S.get_shape()[0], S.get_shape()[1])
-    d = d.asformat("csr")
+    StS = S.T @ S
+    d = SP.dia_matrix(([StS.diagonal()], [0]), shape=S.shape).tocsr()
     return StS - d
 
 
@@ -247,7 +246,7 @@ def get_A1_hom(s, scalarKP=False):
                       A1 matrix in scipy sparse format
     """
     n = float(s.shape[0])
-    wpw = s.T * s
+    wpw = s.T @ s
     twpw = np.sum(wpw.diagonal())
     e = SP.eye(n, n, format="csr")
     e.data = np.ones(int(n)) * (twpw / n)
@@ -311,16 +310,16 @@ def _moments2eqs(A1, s, u):
 
     """
     n = float(s.shape[0])
-    A1u = A1 * u
-    wu = s * u
+    A1u = A1 @ u
+    wu = s @ u
     g1 = np.dot(u.T, A1u)
     g2 = np.dot(u.T, wu)
     g = np.array([[g1][0][0], [g2][0][0]]) / n
 
-    G11 = np.dot(u.T, ((A1 + A1.T) * wu))
-    G12 = -np.dot((wu.T * A1), wu)
-    G21 = np.dot(u.T, ((s + s.T) * wu))
-    G22 = -np.dot(wu.T, (s * wu))
+    G11 = np.dot(u.T, ((A1 + A1.T) @ wu))
+    G12 = -np.dot((wu.T @ A1), wu)
+    G21 = np.dot(u.T, ((s + s.T) @ wu))
+    G22 = -np.dot(wu.T, (s @ wu))
     G = np.array([[G11[0][0], G12[0][0]], [G21[0][0], G22[0][0]]]) / n
     return [G, g]
 
@@ -468,7 +467,7 @@ def get_spFilter(w, lamb, sf):
         ws = w
     T = sf.shape[0] // ws.shape[0]
     if T == 1:
-        result = sf - lamb * (ws * sf)
+        result = sf - lamb * (ws @ sf)
     else:
         result = sf - lamb * SP.kron(SP.identity(T), ws).dot(sf)
     return result
@@ -659,9 +658,9 @@ def power_expansion(
         max_iterations = 10000000
     while test > threshold and count <= max_iterations:
         if post_multiply:
-            increment = increment * ws * scalar
+            increment = increment @ ws * scalar
         else:
-            increment = ws * increment * scalar
+            increment = ws @ increment * scalar
         running_total += increment
         test_old = test
         test = la.norm(increment)
@@ -705,7 +704,7 @@ def set_endog(y, x, w, yend, q, w_lags, lag_q, slx_lags=0,slx_vars="All"):
             if len(slx_vars) != x.shape[1] :
                 raise Exception("slx_vars incompatible with x column dimensions")
             else:  # use slx_vars to extract proper columns
-                vv = slx_vars * slx_lags
+                vv = slx_vars @ slx_lags
                 lag_x = lag_x[:,vv]
             return yend, q, lag_x
         else:  # slx_vars is "All"
@@ -717,22 +716,22 @@ def set_endog_sparse(y, x, w, yend, q, w_lags, lag_q):
     """
     Same as set_endog, but with a sparse object passed as weights instead of W object.
     """
-    yl = w * y
+    yl = w @ y
     # spatial and non-spatial instruments
     if issubclass(type(yend), np.ndarray):
         if lag_q:
             lag_vars = sphstack(x, q)
         else:
             lag_vars = x
-        spatial_inst = w * lag_vars
+        spatial_inst = w @ lag_vars
         for i in range(w_lags - 1):
-            spatial_inst = sphstack(spatial_inst, w * spatial_inst)
+            spatial_inst = sphstack(spatial_inst, w @ spatial_inst)
         q = sphstack(q, spatial_inst)
         yend = sphstack(yend, yl)
     elif yend == None:  # spatial instruments only
-        q = w * x
+        q = w @ x
         for i in range(w_lags - 1):
-            q = sphstack(q, w * q)
+            q = sphstack(q, w @ q)
         yend = yl
     else:
         raise Exception("invalid value passed to yend")

--- a/spreg/w_utils.py
+++ b/spreg/w_utils.py
@@ -20,7 +20,7 @@ def symmetrize(w):
     d = w.sparse.sum(axis=1)  # row sum
     d.shape = (w.n,)
     d = np.sqrt(d)
-    Di12 = SPARSE.spdiags(1.0 / d, [0], w.n, w.n)
-    D12 = SPARSE.spdiags(d, [0], w.n, w.n)
+    Di12 = SPARSE.dia_matrix((1.0 / d, [0]), shape=(w.n, w.n))
+    D12 = SPARSE.dia_matrix((d, [0]), shape=(w.n, w.n))
     w.transform = "r"
-    return D12 * w.sparse * Di12
+    return D12 @ w.sparse @ Di12


### PR DESCRIPTION
As per the SciPy sparray migration guide this is a "pass 1" set of changes.
"Pass 1" essentially makes sure your code is compatible for both sparray and spmatrix. It doesn't actually change any sparse objects to sparray. It changes usage of `*` and `**` and updates/rewrites functions `spdiags` and `get_shape`.

I think this should match what Serge and I worked on at the Scientific Python Summit --  But I'm not sure that we got the `get_shape` parts changed.

I've now gone through all the repos with the tools to switch from `*` to `@`. I have 3 PRs. In `libpysal`, `momepy` and `spreg`.  The others didn't need changes.