### PR TITLE
Adding two-way specification to panels

### DIFF
--- a/notebooks/panels_examples.ipynb
+++ b/notebooks/panels_examples.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Spatial Panel Models in spreg\n",
-    "This notebook presents an usage example of the spatial panel functions available in spreg as of version 1.9.0.\n",
+    "This notebook presents an usage example of the spatial panel functions available in spreg as of version 1.9.1.\n",
     "Prepared by: Luc Anselin and Pedro Amaral"
    ]
   },
@@ -20,28 +20,19 @@
     "\n",
     "For explanatory variables, we will extract RD and PS in the same time periods from the dataframe to be used as independent variables in the regression.\n",
     "\n",
-    "IMPORTANT: If in wide format as in the example below, the data must be organized in a way that all time periods of a given variable are side-by-side and in the correct time order. That is: x[:, 0:T] refers to T periods of k1, x[:, T+1:2T] refers to k2, etc. By default a vector of ones will be added to the independent variables passed in.\n"
+    "IMPORTANT: If in wide format as in the example below, the data must be organized in a way that all time periods of a given variable are side-by-side and in the correct time order. That is: x[:, 0:T] refers to T periods of $k_1$, x[:, T+1:2T] refers to $k_2$, etc. By default a vector of ones will be added to the independent variables passed in.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-01-03T16:26:49.970828Z",
      "start_time": "2021-01-03T16:26:48.621823Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/miniconda3/envs/env14/lib/python3.14/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import libpysal\n",
     "import spreg\n",
@@ -50,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "spreg version 1.9.0 offers the following panel functions (in addition to the SUR estimators):\n",
+    "spreg version 1.9.1 offers the following panel functions (in addition to the SUR estimators):\n",
     "\n",
     "1. OLS and Basic Panel Classes\n",
     "- PooledOLS\n",
@@ -148,12 +139,13 @@
     "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
     "- BSK_list: List of BSK tests to compute if spat_diag is True. \n",
     "                     Options are \"all\", \"LMJ\", \"LM1\", \"LM2\", \"LMC_spatial\", \"LMC_RE\" \n",
-    "                     (default: [\"LMJ\", \"LM1\", \"LM2\"]).\n"
+    "                     (default: [\"LMJ\", \"LM1\", \"LM2\"]).\n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -208,6 +200,68 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can also add time fixed effects with the argument `time_effects=True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "REGRESSION RESULTS\n",
+      "------------------\n",
+      "\n",
+      "SUMMARY OF OUTPUT: POOLED OLS PANEL WITH TIME DUMMIES\n",
+      "------------------------------------------------------------------------------------\n",
+      "Data set            :     unknown\n",
+      "Weights matrix      :     unknown\n",
+      "Dependent Variable  :          HR                Number of Observations:        2367\n",
+      "Mean dependent var  :      8.8420                Number of Variables   :           5\n",
+      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2362\n",
+      "R-squared           :      0.3666\n",
+      "Adjusted R-squared  :      0.3655\n",
+      "Sum squared residual:     82891.8                F-statistic           :    341.7606\n",
+      "Sigma-square        :      35.094                Prob(F-statistic)     :  2.658e-232\n",
+      "S.E. of regression  :       5.924                Log likelihood        :   -7567.051\n",
+      "Sigma-square ML     :      35.020                Akaike info criterion :   15144.102\n",
+      "S.E of regression ML:      5.9178                Schwarz criterion     :   15172.949\n",
+      "\n",
+      "------------------------------------------------------------------------------------\n",
+      "            Variable     Coefficient       Std.Error     t-Statistic     Probability\n",
+      "------------------------------------------------------------------------------------\n",
+      "            CONSTANT         7.80035         0.23029        33.87257         0.00000\n",
+      "                  RD         4.78176         0.13438        35.58493         0.00000\n",
+      "                  PS         1.31468         0.15154         8.67540         0.00000\n",
+      "              time_2        -0.88538         0.29827        -2.96835         0.00302\n",
+      "              time_3        -0.27378         0.29881        -0.91622         0.35964\n",
+      "------------------------------------------------------------------------------------\n",
+      "Warning: Assuming panel is in wide format.\n",
+      "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
+      "x[:, 0:T] refers to T periods of k1, x[:, T+1:2T] refers to k2, etc.\n",
+      "\n",
+      "SPATIAL DIAGNOSTIC TESTS\n",
+      "------------------------------------------------------------------------------------\n",
+      "TEST                             DF        VALUE           PROB\n",
+      "LM Marginal RE (LM1)             1        13.6660        0.00000\n",
+      "LM Marginal Spatial (LM2)        1        19.7664        0.00000\n",
+      "LM Joint (LMJ)                   2       577.4706        0.00000\n",
+      "================================ END OF REPORT =====================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "panel_t = spreg.PooledOLS(y=y_var, x=x_var, w=wq1, spat_diag=True, slx_lags=0, time_effects=True)\n",
+    "print(panel_t.summary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Fixed Effects"
    ]
   },
@@ -221,7 +275,8 @@
     "\n",
     "Optional arguments include (among others):\n",
     "- slx_lags: Number of spatial lags of X to include in the model specification. If slx_lags>0, the specification becomes of the SLX type (integer, default = 0).\n",
-    "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). "
+    "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)"
    ]
   },
   {
@@ -233,29 +288,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "PanelFE\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: FIXED EFFECTS PANEL (ONE-WAY)\n",
+      "SUMMARY OF OUTPUT: FIXED EFFECTS PANEL (TWO-WAY)\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
       "Dependent Variable  :          HR                Number of Observations:        2367\n",
-      "Mean dependent var  :      8.8420                Number of Variables   :           2\n",
-      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2365\n",
-      "Pseudo R-squared    :      0.0362\n",
-      "Sum squared residual:      612992                F-statistic           :   2056.4811\n",
-      "Sigma-square        :      23.750                Prob(F-statistic)     :           0\n",
-      "S.E. of regression  :       4.873                Log likelihood        :   -9935.016\n",
-      "Sigma-square ML     :     258.974                Akaike info criterion :   19874.032\n",
-      "S.E of regression ML:     16.0927                Schwarz criterion     :   19885.571\n",
-      "Fixed-effects mean  :     12.9384\n",
+      "Mean dependent var  :      8.8420                Number of Variables   :           4\n",
+      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2363\n",
+      "Pseudo R-squared    :      0.7154\n",
+      "Sum squared residual:     37242.6                F-statistic           :   1980.1123\n",
+      "Sigma-square        :      23.661                Prob(F-statistic)     :           0\n",
+      "S.E. of regression  :       4.864                Log likelihood        :   -6620.153\n",
+      "Sigma-square ML     :      15.734                Akaike info criterion :   13248.306\n",
+      "S.E of regression ML:      3.9666                Schwarz criterion     :   13271.384\n",
+      "Individual FE mean  :     13.2519\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "                  RD         0.50537         0.42470         1.18996         0.23406\n",
-      "                  PS        -8.02695         1.24083        -6.46899         0.00000\n",
+      "                  RD         0.45933         0.43621         1.05301         0.29233\n",
+      "                  PS        -7.76315         1.24162        -6.25246         0.00000\n",
+      "              time_2        -0.72031         0.24557        -2.93317         0.00336\n",
+      "              time_3        -0.61024         0.25150        -2.42638         0.01525\n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -265,7 +323,7 @@
     }
    ],
    "source": [
-    "panelFE = spreg.PanelFE(y=y_var, x=x_var, w=wq1)\n",
+    "panelFE = spreg.PanelFE(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelFE.summary)"
    ]
   },
@@ -277,11 +335,11 @@
     {
      "data": {
       "text/plain": [
-       "array([[ 3.36232066],\n",
-       "       [ 1.60766964],\n",
-       "       [-0.51299016],\n",
-       "       [ 8.92060208],\n",
-       "       [ 2.99745542]])"
+       "array([[3.74145206],\n",
+       "       [2.07285211],\n",
+       "       [0.11815978],\n",
+       "       [9.14970737],\n",
+       "       [3.50770994]])"
       ]
      },
      "execution_count": 6,
@@ -290,8 +348,8 @@
     }
    ],
    "source": [
-    "# Individual effects (mu_i) for the first 5 observations\n",
-    "panelFE.mu_i[0:5]"
+    "# Individual fixedeffects (fixed_effects) for the first 5 observations\n",
+    "panelFE.fixed_effects[0:5]"
    ]
   },
   {
@@ -313,7 +371,8 @@
     "Optional arguments include (among others):\n",
     "- slx_lags: Number of spatial lags of X to include in the model specification. If slx_lags>0, the specification becomes of the SLX type (integer, default = 0).\n",
     "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
-    "- spat_diag: If True (default), then compute the 'LMC_spatial' BSK test (boolean)."
+    "- spat_diag: If True (default), then compute the 'LMC_spatial' BSK test (boolean).\n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)"
    ]
   },
   {
@@ -325,29 +384,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "PanelRE\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: RANDOM EFFECTS (ONE-WAY) PANEL\n",
+      "SUMMARY OF OUTPUT: RANDOM EFFECTS PANEL (TWO-WAY)\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
       "Dependent Variable  :          HR                Number of Observations:        2367\n",
-      "Mean dependent var  :      8.8420                Number of Variables   :           3\n",
-      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2364\n",
-      "Pseudo R-squared    :      0.3639\n",
-      "Sum squared residual:     83401.1                F-statistic           :    600.5147\n",
-      "Sigma-square        :      24.807                Prob(F-statistic)     :  1.296e-211\n",
-      "S.E. of regression  :       4.981                Log likelihood        :   -7574.300\n",
-      "Sigma-square ML     :      24.807                Akaike info criterion :   15154.600\n",
-      "S.E of regression ML:      4.9806                Schwarz criterion     :   15171.908\n",
+      "Mean dependent var  :      8.8420                Number of Variables   :           5\n",
+      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2362\n",
+      "Pseudo R-squared    :      0.3663\n",
+      "Sum squared residual:     83069.7                F-statistic           :    304.2376\n",
+      "Sigma-square        :      24.634                Prob(F-statistic)     :  2.904e-211\n",
+      "S.E. of regression  :       4.963                Log likelihood        :   -7569.587\n",
+      "Sigma-square ML     :      24.634                Akaike info criterion :   15149.175\n",
+      "S.E of regression ML:      4.9633                Schwarz criterion     :   15178.021\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "            CONSTANT         7.57431         0.19243        39.36224         0.00000\n",
-      "                  RD         4.46700         0.16293        27.41586         0.00000\n",
-      "                  PS         1.10059         0.19119         5.75642         0.00000\n",
+      "            CONSTANT         7.96329         0.24138        32.99033         0.00000\n",
+      "                  RD         4.48233         0.16365        27.39044         0.00000\n",
+      "                  PS         1.11105         0.19109         5.81414         0.00000\n",
+      "              time_2        -0.87882         0.24992        -3.51642         0.00044\n",
+      "              time_3        -0.31160         0.25087        -1.24209         0.21420\n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -355,22 +417,22 @@
       "\n",
       "VARIANCE COMPONENTS ESTIMATES\n",
       "------------------------------------------------------------------------------------\n",
-      "Sigma2_epsilon (Idiosyncratic)         23.7802\n",
-      "Sigma2_mu (Individual)                 10.3181\n",
-      "Theta (Quasi-demeaning weight)          0.3409\n",
+      "Sigma2_epsilon (Idiosyncratic)         23.6611\n",
+      "Sigma2_mu (Individual)                 10.3578\n",
+      "Theta (Quasi-demeaning weight)          0.3425\n",
       "------------------------------------------------------------------------------------\n",
       "\n",
       "DIAGNOSTIC TESTS\n",
       "------------------------------------------------------------------------------------\n",
       "TEST                             DF        VALUE           PROB\n",
-      "Hausman Specification Test       2       107.7615        0.00000\n",
-      "LM Conditional Spatial           1        11.8355        0.00000\n",
+      "Hausman Specification Test       4       104.8838        0.00000\n",
+      "LM Conditional Spatial           1        11.3924        0.00000\n",
       "================================ END OF REPORT =====================================\n"
      ]
     }
    ],
    "source": [
-    "panelRE = spreg.PanelRE(y=y_var, x=x_var, w=wq1)\n",
+    "panelRE = spreg.PanelRE(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelRE.summary)"
    ]
   },
@@ -395,7 +457,8 @@
     "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
     "- max_iter: Maximum number of iterations of steps 2a and 2b from `Arraiz2010` (int, default = 1).\n",
     "- step1c: If True, then include Step 1c from `Arraiz2010` (boolean, default = False).\n",
-    "- nonspat_diag: If True (default), then compute the 'LMC_RE' BSK test."
+    "- nonspat_diag: If True (default), then compute the 'LMC_RE' BSK test.\n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)"
    ]
   },
   {
@@ -407,26 +470,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "GM_ErrorPooled\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: GMM POOLED SPATIAL ERROR MODEL (SEM)\n",
+      "SUMMARY OF OUTPUT: GMM POOLED SPATIAL ERROR MODEL (SEM) WITH TIME EFFECTS\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
       "Dependent Variable  :          HR                Number of Observations:        2367\n",
-      "Mean dependent var  :      8.8420                Number of Variables   :           3\n",
-      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2364\n",
-      "Pseudo R-squared    :      0.3636\n",
+      "Mean dependent var  :      8.8420                Number of Variables   :           5\n",
+      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2362\n",
+      "Pseudo R-squared    :      0.3661\n",
       "N. of iterations    :           1                Step1c computed       :          No\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "            CONSTANT         7.54099         0.27761        27.16348         0.00000\n",
-      "                  RD         4.52263         0.21905        20.64645         0.00000\n",
-      "                  PS         1.06316         0.23034         4.61558         0.00000\n",
-      "              lambda         0.50345         0.02804        17.95214         0.00000\n",
+      "            CONSTANT         7.92549         0.52087        15.21578         0.00000\n",
+      "                  RD         4.52893         0.21980        20.60451         0.00000\n",
+      "                  PS         1.06665         0.22974         4.64295         0.00000\n",
+      "              time_2        -0.88294         0.57053        -1.54758         0.12172\n",
+      "              time_3        -0.27761         0.58097        -0.47784         0.63277\n",
+      "              lambda         0.49960         0.02820        17.71501         0.00000\n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -435,7 +501,7 @@
       "DIAGNOSTIC TESTS\n",
       "------------------------------------------------------------------------------------\n",
       "TEST                             DF        VALUE           PROB\n",
-      "LM Conditional RE                1         8.3638        0.00000\n",
+      "LM Conditional RE                1         8.3469        0.00000\n",
       "Warning: The properties of the LM Conditional RE test using GM have not been\n",
       "         established. We recommend using ML_ErrorPooled.\n",
       "================================ END OF REPORT =====================================\n"
@@ -443,7 +509,7 @@
     }
    ],
    "source": [
-    "panelSEM = spreg.GM_ErrorPooled(y=y_var, x=x_var, w=wq1)\n",
+    "panelSEM = spreg.GM_ErrorPooled(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelSEM.summary)"
    ]
   },
@@ -470,7 +536,8 @@
     "                   if 'ord', Ord eigenvalue calculation (Slow for large Panel); \n",
     "                   if 'full', brute force (Should not use for Panel).\n",
     "\n",
-    "- nonspat_diag: If True (default), then compute the 'LMC_RE' BSK test.                   "
+    "- nonspat_diag: If True (default), then compute the 'LMC_RE' BSK test.\n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)               "
    ]
   },
   {
@@ -482,28 +549,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "ML_ErrorPooled\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: ML POOLED SPATIAL ERROR MODEL (SEM)\n",
+      "SUMMARY OF OUTPUT: ML POOLED SPATIAL ERROR MODEL (SEM) WITH TIME EFFECTS\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
-      "Dependent Variable  :     dep_var                Number of Observations:        2367\n",
-      "Mean dependent var  :      8.8420                Number of Variables   :           3\n",
-      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2364\n",
-      "Pseudo R-squared    :      0.3636\n",
-      "Log likelihood      :  -7416.9763\n",
-      "Sigma-square ML     :     29.5004                Akaike info criterion :   14839.953\n",
-      "S.E of regression   :      5.4314                Schwarz criterion     :   14857.261\n",
+      "Dependent Variable  :          HR                Number of Observations:        2367\n",
+      "Mean dependent var  :      8.8420                Number of Variables   :           5\n",
+      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2362\n",
+      "Pseudo R-squared    :      0.3661\n",
+      "Log likelihood      :  -7415.3400\n",
+      "Sigma-square ML     :     29.4794                Akaike info criterion :   14840.680\n",
+      "S.E of regression   :      5.4295                Schwarz criterion     :   14869.527\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "            CONSTANT         7.54329         0.22626        33.33920         0.00000\n",
-      "                  RD         4.51673         0.15559        29.03023         0.00000\n",
-      "                  PS         1.05694         0.16540         6.39042         0.00000\n",
-      "              lambda         0.45384         0.02472        18.36254         0.00000\n",
+      "            CONSTANT         7.92772         0.36546        21.69220         0.00000\n",
+      "                  RD         4.52292         0.15549        29.08778         0.00000\n",
+      "                  PS         1.06039         0.16516         6.42020         0.00000\n",
+      "              time_2        -0.88297         0.49770        -1.77409         0.07605\n",
+      "              time_3        -0.27716         0.49814        -0.55639         0.57795\n",
+      "              lambda         0.45075         0.02479        18.18283         0.00000\n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -512,13 +582,13 @@
       "DIAGNOSTIC TESTS\n",
       "------------------------------------------------------------------------------------\n",
       "TEST                             DF        VALUE           PROB\n",
-      "LM Conditional RE                1         7.7786        0.00000\n",
+      "LM Conditional RE                1         7.7867        0.00000\n",
       "================================ END OF REPORT =====================================\n"
      ]
     }
    ],
    "source": [
-    "panelML_SEM = spreg.ML_ErrorPooled(y=y_var, x=x_var, w=wq1)\n",
+    "panelML_SEM = spreg.ML_ErrorPooled(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelML_SEM.summary)"
    ]
   },
@@ -544,7 +614,8 @@
     "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
     "- full_weights: (boolean) Considers different weights for each of the 6 moment\n",
     "                  conditions if True or only 2 sets of weights for the\n",
-    "                  first 3 and the last 3 moment conditions if False (default)"
+    "                  first 3 and the last 3 moment conditions if False (default)\n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)."
    ]
   },
   {
@@ -556,27 +627,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "GM_ErrorRE\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: GMM SPATIAL ERROR PANEL MODEL - RANDOM EFFECTS (KKP)\n",
+      "SUMMARY OF OUTPUT: GMM SPATIAL ERROR PANEL MODEL - RANDOM EFFECTS (KKP) WITH TIME EFFECTS\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
       "Dependent Variable  :          HR                Number of Observations:        2367\n",
-      "Mean dependent var  :      8.8420                Number of Variables   :           3\n",
-      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2364\n",
-      "Pseudo R-squared    :      0.3634\n",
+      "Mean dependent var  :      8.8420                Number of Variables   :           5\n",
+      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2362\n",
+      "Pseudo R-squared    :      0.3658\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "            CONSTANT         7.61779         0.26073        29.21762         0.00000\n",
-      "                  RD         4.33248         0.17641        24.55953         0.00000\n",
-      "                  PS         0.97987         0.19391         5.05331         0.00000\n",
-      "              lambda         0.43686    \n",
-      "            sigma2_v        23.90314    \n",
-      "            sigma2_1        41.39357    \n",
+      "            CONSTANT         8.00947         0.36223        22.11171         0.00000\n",
+      "                  RD         4.33873         0.17675        24.54686         0.00000\n",
+      "                  PS         0.98289         0.19398         5.06702         0.00000\n",
+      "              time_2        -0.87936         0.43506        -2.02123         0.04326\n",
+      "              time_3        -0.30258         0.43570        -0.69446         0.48739\n",
+      "              lambda         0.43481    \n",
+      "            sigma2_v        23.83305    \n",
+      "            sigma2_1        41.44246    \n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -586,7 +660,7 @@
     }
    ],
    "source": [
-    "panelSEM_RE = spreg.GM_ErrorRE(y=y_var, x=x_var, w=wq1)\n",
+    "panelSEM_RE = spreg.GM_ErrorRE(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelSEM_RE.summary)"
    ]
   },
@@ -609,7 +683,8 @@
     "\n",
     "Optional arguments include (among others):\n",
     "- slx_lags: Number of spatial lags of X to include in the model specification. If slx_lags>0, the specification becomes of the SLX type (integer, default = 0).\n",
-    "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). "
+    "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)."
    ]
   },
   {
@@ -621,26 +696,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "ML_ErrorRE\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: ML SPATIAL ERROR PANEL MODEL (SEM) - RANDOM EFFECTS\n",
+      "SUMMARY OF OUTPUT: ML SPATIAL ERROR PANEL MODEL (SEM) - RANDOM EFFECTS WITH TIME EFFECTS\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
       "Dependent Variable  :          HR                Number of Observations:        2367\n",
-      "Mean dependent var  :      8.8420                Number of Variables   :           3\n",
-      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2364\n",
-      "Pseudo R-squared    :      0.3638\n",
+      "Mean dependent var  :      8.8420                Number of Variables   :           5\n",
+      "S.D. dependent var  :      7.4372                Degrees of Freedom    :        2362\n",
+      "Pseudo R-squared    :      0.3662\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "            CONSTANT         7.58728         0.22993        32.99879         0.00000\n",
-      "                  RD         4.39257         0.17090        25.70273         0.00000\n",
-      "                  PS         1.05883         0.18969         5.58183         0.00000\n",
-      "              lambda         0.44058         0.00496        88.90567         0.00000\n",
-      "            sigma2_u         6.02048         0.03671       164.01180         0.00000\n",
+      "            CONSTANT         7.97586         0.34060        23.41702         0.00000\n",
+      "                  RD         4.40256         0.17082        25.77277         0.00000\n",
+      "                  PS         1.06403         0.18945         5.61627         0.00000\n",
+      "              time_2        -0.88101         0.43623        -2.01959         0.04343\n",
+      "              time_3        -0.29602         0.43681        -0.67769         0.49797\n",
+      "              lambda         0.43445         0.00506        85.93267         0.00000\n",
+      "            sigma2_u         6.07456         0.03674       165.31880         0.00000\n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -650,7 +728,7 @@
     }
    ],
    "source": [
-    "panelSEM_RE = spreg.ML_ErrorRE(y=y_var, x=x_var, w=wq1)\n",
+    "panelSEM_RE = spreg.ML_ErrorRE(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelSEM_RE.summary)"
    ]
   },
@@ -670,7 +748,8 @@
     "\n",
     "Optional arguments include (among others):\n",
     "- slx_lags: Number of spatial lags of X to include in the model specification. If slx_lags>0, the specification becomes of the SLX type (integer, default = 0).\n",
-    "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). "
+    "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)."
    ]
   },
   {
@@ -682,28 +761,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "ML_ErrorFE\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: ML SPATIAL ERROR PANEL MODEL - FIXED EFFECTS\n",
+      "SUMMARY OF OUTPUT: ML SPATIAL ERROR PANEL MODEL - FIXED EFFECTS WITH TIME EFFECTS\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
       "Dependent Variable  :          HR                Number of Observations:        2367\n",
-      "Mean dependent var  :      0.0000                Number of Variables   :           2\n",
-      "S.D. dependent var  :      4.0669                Degrees of Freedom    :        2365\n",
-      "Pseudo R-squared    :      0.0422\n",
-      "Log likelihood      :  -6608.0839\n",
-      "Sigma-square ML     :     15.4572                Akaike info criterion :   13220.168\n",
-      "S.E of regression   :      3.9316                Schwarz criterion     :   13231.706\n",
-      "Fixed-effects mean  :     12.7425\n",
+      "Mean dependent var  :      0.0000                Number of Variables   :           4\n",
+      "S.D. dependent var  :      4.0669                Degrees of Freedom    :        2363\n",
+      "Pseudo R-squared    :      0.0482\n",
+      "Log likelihood      :  -6603.0402\n",
+      "Sigma-square ML     :     15.4047                Akaike info criterion :   13214.080\n",
+      "S.E of regression   :      3.9249                Schwarz criterion     :   13237.158\n",
+      "Individual FE mean  :     13.0962\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "                  RD         0.60867         0.36417         1.67139         0.09465\n",
-      "                  PS        -7.68123         1.08867        -7.05559         0.00000\n",
-      "              lambda         0.19578         0.02973         6.58437         0.00000\n",
+      "                  RD         0.57502         0.37000         1.55413         0.12015\n",
+      "                  PS        -7.50039         1.08379        -6.92055         0.00000\n",
+      "              time_2        -0.73178         0.24282        -3.01372         0.00258\n",
+      "              time_3        -0.59552         0.24712        -2.40989         0.01596\n",
+      "              lambda         0.18464         0.02990         6.17509         0.00000\n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -713,7 +795,7 @@
     }
    ],
    "source": [
-    "panelSEM_FE = spreg.ML_ErrorFE(y=y_var, x=x_var, w=wq1)\n",
+    "panelSEM_FE = spreg.ML_ErrorFE(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelSEM_FE.summary)"
    ]
   },
@@ -725,11 +807,11 @@
     {
      "data": {
       "text/plain": [
-       "array([[ 3.31195411],\n",
-       "       [ 1.67335124],\n",
-       "       [-0.18020496],\n",
-       "       [ 8.72536659],\n",
-       "       [ 3.03582746]])"
+       "array([[3.70982062],\n",
+       "       [2.1301645 ],\n",
+       "       [0.38974858],\n",
+       "       [9.01973087],\n",
+       "       [3.5246372 ]])"
       ]
      },
      "execution_count": 13,
@@ -738,8 +820,8 @@
     }
    ],
    "source": [
-    "# Individual effects (mu_i) for the first 5 observations\n",
-    "panelSEM_FE.mu_i[0:5]"
+    "# Individual fixed effects (mu_i) for the first 5 observations\n",
+    "panelSEM_FE.fixed_effects[0:5]"
    ]
   },
   {
@@ -762,7 +844,8 @@
     "- spat_impacts: Include average direct impact (ADI), average indirect impact (AII),\n",
     "                    and average total impact (ATI) in summary results;\n",
     "                    Options are 'simple', 'full', 'power', 'all' or None;\n",
-    "                    (str or list, default = 'simple').\n"
+    "                    (str or list, default = 'simple').\n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False).\n"
    ]
   },
   {
@@ -774,29 +857,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "ML_LagRE\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: ML SPATIAL LAG PANEL - RANDOM EFFECTS\n",
+      "SUMMARY OF OUTPUT: ML SPATIAL LAG PANEL - RANDOM EFFECTS WITH TIME EFFECTS\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
       "Dependent Variable  :          HR                Number of Observations:        2367\n",
-      "Mean dependent var  :      6.5609                Number of Variables   :           4\n",
-      "S.D. dependent var  :      6.1552                Degrees of Freedom    :        2363\n",
-      "Pseudo R-squared    :      0.3692\n",
-      "Log likelihood      :  -7383.2780\n",
-      "Sigma-square ML     :     23.9269                Akaike info criterion :   14774.556\n",
-      "S.E of regression   :      4.8915                Schwarz criterion     :   14797.633\n",
+      "Mean dependent var  :      6.5463                Number of Variables   :           7\n",
+      "S.D. dependent var  :      6.1475                Degrees of Freedom    :        2360\n",
+      "Pseudo R-squared    :      0.3699\n",
+      "Log likelihood      :  -7379.9922\n",
+      "Sigma-square ML     :     23.8393                Akaike info criterion :   14773.984\n",
+      "S.E of regression   :      4.8826                Schwarz criterion     :   14814.370\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "            CONSTANT         4.50846         0.26075        17.29006         0.00000\n",
-      "                  RD         3.58070         0.16225        22.06916         0.00000\n",
-      "                  PS         1.19552         0.16745         7.13966         0.00000\n",
-      "                W_HR         0.35801         0.02398        14.92908         0.00000\n",
-      "                 phi         0.74201         0.02132        34.80229         0.00000\n",
+      "            CONSTANT         4.75649         0.30540        15.57459         0.00000\n",
+      "                  RD         3.60734         0.16273        22.16809         0.00000\n",
+      "                  PS         1.20358         0.16758         7.18209         0.00000\n",
+      "              time_2        -0.58553         0.24670        -2.37351         0.01762\n",
+      "              time_3        -0.08517         0.24690        -0.34497         0.73012\n",
+      "                W_HR         0.35428         0.02405        14.73405         0.00000\n",
+      "                 phi         0.74036         0.02129        34.77480         0.00000\n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -805,14 +891,16 @@
       "SPATIAL LAG MODEL IMPACTS\n",
       "Impacts computed using the 'simple' method.\n",
       "            Variable         Direct        Indirect          Total\n",
-      "                  RD         3.5807          1.9968          5.5775\n",
-      "                  PS         1.1955          0.6667          1.8622\n",
+      "                  RD         3.6073          1.9792          5.5866\n",
+      "                  PS         1.2036          0.6604          1.8639\n",
+      "              time_2        -0.5855         -0.3213         -0.9068\n",
+      "              time_3        -0.0852         -0.0467         -0.1319\n",
       "================================ END OF REPORT =====================================\n"
      ]
     }
    ],
    "source": [
-    "panelSAR_RE = spreg.ML_LagRE(y=y_var, x=x_var, w=wq1)\n",
+    "panelSAR_RE = spreg.ML_LagRE(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelSAR_RE.summary)"
    ]
   },
@@ -837,7 +925,8 @@
     "- spat_impacts: Include average direct impact (ADI), average indirect impact (AII),\n",
     "                    and average total impact (ATI) in summary results;\n",
     "                    Options are 'simple', 'full', 'power', 'all' or None;\n",
-    "                    (str or list, default = 'simple').\n"
+    "                    (str or list, default = 'simple').\n",
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False).                    \n"
    ]
   },
   {
@@ -849,28 +938,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "ML_LagFE\n",
       "REGRESSION RESULTS\n",
       "------------------\n",
       "\n",
-      "SUMMARY OF OUTPUT: ML SPATIAL LAG PANEL - FIXED EFFECTS\n",
+      "SUMMARY OF OUTPUT: ML SPATIAL LAG PANEL - FIXED EFFECTS WITH TIME EFFECTS\n",
       "------------------------------------------------------------------------------------\n",
       "Data set            :     unknown\n",
       "Weights matrix      :     unknown\n",
       "Dependent Variable  :          HR                Number of Observations:        2367\n",
-      "Mean dependent var  :      0.0000                Number of Variables   :           3\n",
-      "S.D. dependent var  :      4.0669                Degrees of Freedom    :        2364\n",
-      "Pseudo R-squared    :      0.0659\n",
-      "Log likelihood      :  -6607.9807\n",
-      "Sigma-square ML     :     15.4592                Akaike info criterion :   13221.961\n",
-      "S.E of regression   :      3.9318                Schwarz criterion     :   13239.269\n",
-      "Fixed-effects mean  :     12.4434\n",
+      "Mean dependent var  :      0.0000                Number of Variables   :           5\n",
+      "S.D. dependent var  :      4.0669                Degrees of Freedom    :        2362\n",
+      "Pseudo R-squared    :      0.0684\n",
+      "Log likelihood      :  -6603.2997\n",
+      "Sigma-square ML     :     15.4124                Akaike info criterion :   13216.599\n",
+      "S.E of regression   :      3.9259                Schwarz criterion     :   13245.446\n",
+      "Individual FE mean  :     11.1174\n",
       "\n",
       "------------------------------------------------------------------------------------\n",
       "            Variable     Coefficient       Std.Error     z-Statistic     Probability\n",
       "------------------------------------------------------------------------------------\n",
-      "                  RD         0.52398         0.34274         1.52880         0.12631\n",
-      "                  PS        -7.08071         1.00944        -7.01449         0.00000\n",
-      "                W_HR         0.19301         0.02930         6.58807         0.00000\n",
+      "                  RD         0.50779         0.35209         1.44222         0.14924\n",
+      "                  PS        -6.92694         1.00983        -6.85953         0.00000\n",
+      "              time_2        -0.58665         0.19954        -2.93997         0.00328\n",
+      "              time_3        -0.44757         0.20437        -2.18999         0.02852\n",
+      "                W_HR         0.18083         0.02952         6.12514         0.00000\n",
       "------------------------------------------------------------------------------------\n",
       "Warning: Assuming panel is in wide format.\n",
       "y[:, 0] refers to T0, y[:, 1] refers to T1, etc.\n",
@@ -879,14 +971,16 @@
       "SPATIAL LAG MODEL IMPACTS\n",
       "Impacts computed using the 'simple' method.\n",
       "            Variable         Direct        Indirect          Total\n",
-      "                  RD         0.5240          0.1253          0.6493\n",
-      "                  PS        -7.0807         -1.6935         -8.7742\n",
+      "                  RD         0.5078          0.1121          0.6199\n",
+      "                  PS        -6.9269         -1.5291         -8.4560\n",
+      "              time_2        -0.5866         -0.1295         -0.7161\n",
+      "              time_3        -0.4476         -0.0988         -0.5464\n",
       "================================ END OF REPORT =====================================\n"
      ]
     }
    ],
    "source": [
-    "panelSAR_FE = spreg.ML_LagFE(y=y_var, x=x_var, w=wq1)\n",
+    "panelSAR_FE = spreg.ML_LagFE(y=y_var, x=x_var, w=wq1, time_effects=True)\n",
     "print(panelSAR_FE.summary)"
    ]
   },
@@ -898,11 +992,11 @@
     {
      "data": {
       "text/plain": [
-       "array([[3.16956916],\n",
-       "       [1.72726064],\n",
-       "       [0.25762143],\n",
-       "       [8.24781692],\n",
-       "       [3.18171931]])"
+       "array([[2.76615386],\n",
+       "       [1.55072091],\n",
+       "       [0.29991187],\n",
+       "       [7.93198396],\n",
+       "       [3.20451278]])"
       ]
      },
      "execution_count": 16,
@@ -911,8 +1005,8 @@
     }
    ],
    "source": [
-    "# Individual effects (mu_i) for the first 5 observations\n",
-    "panelSAR_FE.mu_i[0:5]"
+    "# Individual fixed effects (mu_i) for the first 5 observations\n",
+    "panelSAR_FE.fixed_effects[0:5]"
    ]
   }
  ],
@@ -932,7 +1026,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.2"
+   "version": "3.14.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/panels_examples.ipynb
+++ b/notebooks/panels_examples.ipynb
@@ -140,7 +140,7 @@
     "- BSK_list: List of BSK tests to compute if spat_diag is True. \n",
     "                     Options are \"all\", \"LMJ\", \"LM1\", \"LM2\", \"LMC_spatial\", \"LMC_RE\" \n",
     "                     (default: [\"LMJ\", \"LM1\", \"LM2\"]).\n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)\n"
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False)\n"
    ]
   },
   {
@@ -276,7 +276,7 @@
     "Optional arguments include (among others):\n",
     "- slx_lags: Number of spatial lags of X to include in the model specification. If slx_lags>0, the specification becomes of the SLX type (integer, default = 0).\n",
     "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)"
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False)"
    ]
   },
   {
@@ -372,7 +372,7 @@
     "- slx_lags: Number of spatial lags of X to include in the model specification. If slx_lags>0, the specification becomes of the SLX type (integer, default = 0).\n",
     "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
     "- spat_diag: If True (default), then compute the 'LMC_spatial' BSK test (boolean).\n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)"
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False)"
    ]
   },
   {
@@ -458,7 +458,7 @@
     "- max_iter: Maximum number of iterations of steps 2a and 2b from `Arraiz2010` (int, default = 1).\n",
     "- step1c: If True, then include Step 1c from `Arraiz2010` (boolean, default = False).\n",
     "- nonspat_diag: If True (default), then compute the 'LMC_RE' BSK test.\n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)"
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False)"
    ]
   },
   {
@@ -537,7 +537,7 @@
     "                   if 'full', brute force (Should not use for Panel).\n",
     "\n",
     "- nonspat_diag: If True (default), then compute the 'LMC_RE' BSK test.\n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)               "
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False)               "
    ]
   },
   {
@@ -615,7 +615,7 @@
     "- full_weights: (boolean) Considers different weights for each of the 6 moment\n",
     "                  conditions if True or only 2 sets of weights for the\n",
     "                  first 3 and the last 3 moment conditions if False (default)\n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)."
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False)."
    ]
   },
   {
@@ -684,7 +684,7 @@
     "Optional arguments include (among others):\n",
     "- slx_lags: Number of spatial lags of X to include in the model specification. If slx_lags>0, the specification becomes of the SLX type (integer, default = 0).\n",
     "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)."
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False)."
    ]
   },
   {
@@ -749,7 +749,7 @@
     "Optional arguments include (among others):\n",
     "- slx_lags: Number of spatial lags of X to include in the model specification. If slx_lags>0, the specification becomes of the SLX type (integer, default = 0).\n",
     "- slx_vars: \"all\" or list of booleans to select x variables to be lagged (str or list, default = \"all\"). \n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False)."
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False)."
    ]
   },
   {
@@ -845,7 +845,7 @@
     "                    and average total impact (ATI) in summary results;\n",
     "                    Options are 'simple', 'full', 'power', 'all' or None;\n",
     "                    (str or list, default = 'simple').\n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False).\n"
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False).\n"
    ]
   },
   {
@@ -926,7 +926,7 @@
     "                    and average total impact (ATI) in summary results;\n",
     "                    Options are 'simple', 'full', 'power', 'all' or None;\n",
     "                    (str or list, default = 'simple').\n",
-    "- time_effects: If True, then include time dummies in the model specification (the first time period is ommitted), (boolean, default = False).                    \n"
+    "- time_effects: If True, then include time dummies in the model specification (the first time period is omitted), (boolean, default = False).                    \n"
    ]
   },
   {

--- a/notebooks/panels_examples.ipynb
+++ b/notebooks/panels_examples.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Spatial Panel Models in spreg\n",
-    "This notebook presents an usage example of the spatial panel functions available in spreg as of version 1.9.1.\n",
+    "This notebook presents a usage example of the spatial panel functions available in spreg as of version 1.9.1.\n",
     "Prepared by: Luc Anselin and Pedro Amaral"
    ]
   },
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-01-03T16:26:49.970828Z",
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -281,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -342,7 +342,7 @@
        "       [3.50770994]])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -377,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -542,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -620,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -689,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -754,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -801,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -814,7 +814,7 @@
        "       [3.5246372 ]])"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -850,7 +850,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -931,7 +931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -986,7 +986,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -999,7 +999,7 @@
        "       [3.20451278]])"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/spreg/panel.py
+++ b/spreg/panel.py
@@ -46,7 +46,7 @@ class PooledOLS(BaseOLS, RegressionPropsY, RegressionPropsVM):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False.
     robust       : string, optional
                    If 'white', then a White consistent estimator of the
@@ -180,7 +180,7 @@ class PooledOLS(BaseOLS, RegressionPropsY, RegressionPropsVM):
     ):
 
         self.title = "POOLED OLS PANEL"
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
 
@@ -236,7 +236,7 @@ class PanelFE(RegressionPropsY, RegressionPropsVM):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                     to be lagged
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                    
     vm           : boolean
                    if True, include variance-covariance matrix in summary
@@ -351,7 +351,7 @@ class PanelFE(RegressionPropsY, RegressionPropsVM):
     ):
         
         self.title = "FIXED EFFECTS PANEL "
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=False)
         any(set_warn(self, i) for i in warn)
   
@@ -428,7 +428,7 @@ class PanelRE(RegressionPropsY, RegressionPropsVM):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                   
     spat_diag    : boolean
                    If True (default), then compute the 'LMC_spatial' BSK test.
@@ -544,7 +544,7 @@ class PanelRE(RegressionPropsY, RegressionPropsVM):
     ):
         
         self.title = "RANDOM EFFECTS PANEL "
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
   
@@ -737,7 +737,7 @@ class GM_ErrorPooled(BaseGM_ErrorPooled):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                   
     nonspat_diag  : boolean
                    If True (default), then compute the 'LMC_RE' BSK test.
@@ -864,7 +864,7 @@ class GM_ErrorPooled(BaseGM_ErrorPooled):
     ):
 
         self.title = "GMM POOLED SPATIAL ERROR MODEL (SEM)"
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
         self.k = bigx.shape[1]
@@ -959,7 +959,7 @@ class ML_ErrorPooled(BaseML_ErrorPooled):
     slx_vars     : string
                    List of variables to apply spatial lag to. Default is "all".
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                   
     nonspat_diag : boolean
                    If True (default), then compute the 'LMC_RE' BSK test.
@@ -1078,7 +1078,7 @@ class ML_ErrorPooled(BaseML_ErrorPooled):
         latex=False,
     ):
         self.title = "ML POOLED SPATIAL ERROR MODEL (SEM)"
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
   
@@ -1364,7 +1364,7 @@ class GM_ErrorRE(BaseGM_ErrorRE, REGI.Regimes_Frame):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged                
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                    
     full_weights: boolean
                   Considers different weights for each of the 6 moment
@@ -1489,7 +1489,7 @@ class GM_ErrorRE(BaseGM_ErrorRE, REGI.Regimes_Frame):
         latex=False,
     ):
         self.title = "GMM SPATIAL ERROR PANEL MODEL - RANDOM EFFECTS (KKP)"
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
    
@@ -1728,7 +1728,7 @@ class ML_ErrorFE(BaseML_ErrorFE):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged                   
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                   
     epsilon      : float
                    tolerance criterion in mimimize_scalar function and
@@ -1881,7 +1881,7 @@ class ML_ErrorFE(BaseML_ErrorFE):
     ):
 
         self.title = "ML SPATIAL ERROR PANEL MODEL - FIXED EFFECTS"
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=False)
         any(set_warn(self, i) for i in warn)
   
@@ -1901,7 +1901,6 @@ class ML_ErrorFE(BaseML_ErrorFE):
         self.output = pd.DataFrame(self.name_x, columns=['var_names'])
         self.output['var_type'] = ['x'] * kx + ['wx'] * kwx + ["lambda"]
         self.output['regime'], self.output['equation'] = (0, 0)
-
         self.aic = DIAG.akaike(reg=self)
         self.schwarz = DIAG.schwarz(reg=self)
         self.other_top = _nonspat_top(self, ml=True)      
@@ -2195,7 +2194,7 @@ class ML_ErrorRE(BaseML_ErrorRE):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged            
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                          
     epsilon      : float
                    tolerance criterion in mimimize_scalar function and
@@ -2345,7 +2344,7 @@ class ML_ErrorRE(BaseML_ErrorRE):
         latex=False,
     ):
         self.title = "ML SPATIAL ERROR PANEL MODEL (SEM) - RANDOM EFFECTS"
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
   
@@ -2565,7 +2564,7 @@ class ML_LagFE(BaseML_LagFE):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged    
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                                  
     epsilon      : float
                    tolerance criterion in mimimize_scalar function and
@@ -2729,7 +2728,7 @@ class ML_LagFE(BaseML_LagFE):
     ):
         self.title = "ML SPATIAL LAG PANEL - FIXED EFFECTS"
 
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=False)
         any(set_warn(self, i) for i in warn)
   
@@ -2766,7 +2765,7 @@ class ML_LagFE(BaseML_LagFE):
         self.other_top += "%-20s:%12.4f\n" % (
             "Individual FE mean", self.mean_mu_i)        
         if spat_impacts:
-            self.sp_multipliers, impacts_str = _summary_impacts(self, w, spat_impacts, slx_lags,slx_vars)
+            self.sp_multipliers, impacts_str = _summary_impacts(self, w, spat_impacts, self.slx_lags, self.slx_vars)
             other_end += impacts_str
         output(reg=self, vm=vm, other_end=other_end, latex=latex)
 
@@ -3025,7 +3024,7 @@ class ML_LagRE(BaseML_LagRE):
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged    
     time_effects : boolean
-                   If True, then include time dummies in the model specification (first ommitted).
+                   If True, then include time dummies in the model specification (first omitted).
                    Default: False                   
     spat_impacts : string or list
                    Include average direct impact (ADI), average indirect impact (AII),
@@ -3180,7 +3179,7 @@ class ML_LagRE(BaseML_LagRE):
 
         self.title = "ML SPATIAL LAG PANEL - RANDOM EFFECTS"
 
-        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
+        bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.slx_vars, self.title, kx, kwx, self.t = prepare_panel(
             y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
   
@@ -3202,6 +3201,6 @@ class ML_LagRE(BaseML_LagRE):
         self.other_top, self.other_mid, other_end = ("", "", "")
         self.other_top += _nonspat_top(self, ml=True)
         if spat_impacts:
-            self.sp_multipliers, impacts_str = _summary_impacts(self, w, spat_impacts, slx_lags,slx_vars)
+            self.sp_multipliers, impacts_str = _summary_impacts(self, w, spat_impacts, self.slx_lags, self.slx_vars)
             other_end += impacts_str
         output(reg=self, vm=vm, other_end=other_end, latex=latex)

--- a/spreg/panel.py
+++ b/spreg/panel.py
@@ -11,7 +11,7 @@ from .diagnostics_panel import BSK_tests
 from .utils import RegressionPropsY, RegressionPropsVM, set_warn, optim_moments, get_spFilter, spdot, inverse_prod
 from .sputils import spdot, spfill_diagonal, spinv
 from .ols import BaseOLS
-from .panel_utils import prepare_panel, demean_panel
+from .panel_utils import prepare_panel, demean_panel, time_inv_check
 from .output import output, _nonspat_mid, _nonspat_top, _summary_iteration, _summary_impacts
 from . import regimes as REGI
 from . import user_output as USER
@@ -45,6 +45,9 @@ class PooledOLS(BaseOLS, RegressionPropsY, RegressionPropsVM):
                    If slx_lags>0, the specification becomes of the SLX type.
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False.
     robust       : string, optional
                    If 'white', then a White consistent estimator of the
                    variance-covariance matrix is given. 
@@ -163,6 +166,7 @@ class PooledOLS(BaseOLS, RegressionPropsY, RegressionPropsVM):
         w,
         slx_lags = 0,
         slx_vars = "all",
+        time_effects=False,
         robust=None,
         vm=False,
         nonspat_diag=False,
@@ -177,9 +181,12 @@ class PooledOLS(BaseOLS, RegressionPropsY, RegressionPropsVM):
 
         self.title = "POOLED OLS PANEL"
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=True)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
-        
+
+        if time_effects:
+            self.title += " WITH TIME DUMMIES"
+
         self.k = bigx.shape[1]
         
         BaseOLS.__init__(self, bigy, bigx, robust=robust, sig2n_k=True)
@@ -207,7 +214,7 @@ class PooledOLS(BaseOLS, RegressionPropsY, RegressionPropsVM):
 
 class PanelFE(RegressionPropsY, RegressionPropsVM):
     """
-    Fixed Effects (One-Way) OLS for Panel Data.
+    Fixed Effects (One-Way or Two-Way) OLS for Panel Data.
     
     This model controls for time-invariant unobserved heterogeneity by 
     demeaning the data (Within Transformation) before estimation. 
@@ -228,6 +235,9 @@ class PanelFE(RegressionPropsY, RegressionPropsVM):
                     Number of spatial lags of X to include in the model specification.
     slx_vars     : either "All" (default) or list of booleans to select x variables
                     to be lagged
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                    
     vm           : boolean
                    if True, include variance-covariance matrix in summary
                    results
@@ -255,8 +265,10 @@ class PanelFE(RegressionPropsY, RegressionPropsVM):
                    (nxt)x1 array of residuals
     predy        : array
                    (nxt)x1 array of predicted y values
+    mu_i         : array
+                   nx1 array of the individual fixed effects
     fixed_effects: array
-                   nx1 array of the estimated fixed effects (mu_i)
+                   alias for mu_i (same object)
     n            : integer
                    Total number of observations (N * T)
     t            : integer
@@ -329,6 +341,7 @@ class PanelFE(RegressionPropsY, RegressionPropsVM):
         w,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         vm=False,
         name_y=None,
         name_x=None,
@@ -337,11 +350,16 @@ class PanelFE(RegressionPropsY, RegressionPropsVM):
         latex=False,
     ):
         
-        self.title = "FIXED EFFECTS PANEL (ONE-WAY)"
+        self.title = "FIXED EFFECTS PANEL "
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=False)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=False)
         any(set_warn(self, i) for i in warn)
   
+        if time_effects:
+            self.title += "(TWO-WAY)"
+        else:
+            self.title += "(ONE-WAY)"
+
         self.k = bigx.shape[1]
 
         # Demean
@@ -349,33 +367,26 @@ class PanelFE(RegressionPropsY, RegressionPropsVM):
         NT = bigy.shape[0]
         T = NT // N
         
-        y_mat = bigy.reshape((T, N))
-        x_mat = bigx.reshape((T, N, self.k))
-        
-        y_mean = y_mat.mean(axis=0)
-        x_mean = x_mat.mean(axis=0)
-        
-        dem_y = bigy - np.tile(y_mean, T).reshape(-1, 1)
-        
-        dem_x = np.zeros_like(bigx)
-        for i in range(self.k):
-            col_mean = x_mean[:, i] 
-            col_vals = bigx[:, i] 
-            dem_x[:, i] = col_vals - np.tile(col_mean, T)
+        dem_y = demean_panel(bigy, N, T, phi=0)
+        dem_x = demean_panel(bigx, N, T, phi=0)
+
+        time_inv_check(dem_x, self.name_x)
 
         reg_ols = BaseOLS(dem_y, dem_x, sig2n_k=False)
         self.y, self.x = bigy, bigx
         self.betas = reg_ols.betas
-        self.predy = np.dot(bigx, self.betas)
-        self.u = bigy - self.predy
-        self.xtxi = la.inv(np.dot(bigx.T, bigx))
-        self.df_resid = NT - N
 
-        ssr = reg_ols.u.T @ reg_ols.u
+        raw_u = bigy - np.dot(bigx, self.betas)
+        self.fixed_effects = raw_u.reshape(T, N).mean(axis=0).reshape(-1, 1)
+        self.u = reg_ols.u
+        self.predy = bigy - self.u
+
+        self.xtxi = reg_ols.xtxi
+        self.df_resid = NT - N - self.k
+        ssr = self.u.T @ self.u
         self.sig2 = ssr[0, 0] / self.df_resid
         self.vm = np.dot(self.sig2, reg_ols.xtxi)
         self.std_err = np.sqrt(np.diag(self.vm))
-        self.fixed_effects = y_mean.reshape(-1, 1) - (x_mean @ self.betas)
 
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_w = USER.set_name_w(name_w, w)
@@ -387,16 +398,16 @@ class PanelFE(RegressionPropsY, RegressionPropsVM):
         self.other_top, self.other_mid, other_end = ("", "", "") 
         self.other_top += _nonspat_top(self)
 
-        self.mu_i = self.u.reshape(self.t, N).mean(axis=0).reshape(-1, 1)        
-        self.mean_mu_i = self.mu_i.mean()
+        self.mean_mu_i = self.fixed_effects.mean()
+        self.mu_i = self.fixed_effects
         self.other_top += "%-20s:%12.4f\n" % (
-            "Fixed-effects mean", self.mean_mu_i)        
+            "Individual FE mean", self.mean_mu_i)        
 
         output(reg=self, vm=vm, other_end=other_end, latex=latex)
 
 class PanelRE(RegressionPropsY, RegressionPropsVM):
     """
-    Random Effects (One-Way) GLS for Panel Data.
+    Random Effects (One-Way or Two-Way) GLS for Panel Data.
     
     Includes the Swamy-Arora estimator for variance components and 
     the classic Hausman Specification Test (not robust to spatial autocorrelation).
@@ -416,6 +427,9 @@ class PanelRE(RegressionPropsY, RegressionPropsVM):
                    If slx_lags>0, the specification becomes of the SLX type.
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                   
     spat_diag    : boolean
                    If True (default), then compute the 'LMC_spatial' BSK test.
     vm           : boolean
@@ -519,6 +533,7 @@ class PanelRE(RegressionPropsY, RegressionPropsVM):
         w,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         spat_diag=True,
         vm=False,
         name_y=None,
@@ -528,15 +543,23 @@ class PanelRE(RegressionPropsY, RegressionPropsVM):
         latex=False,
     ):
         
-        self.title = "RANDOM EFFECTS (ONE-WAY) PANEL"
+        self.title = "RANDOM EFFECTS PANEL "
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=True)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
+  
+        if time_effects:
+            self.title += "(TWO-WAY)"
+        else:
+            self.title += "(ONE-WAY)"        
 
         self.k = bigx.shape[1]
         
         N = w.n
         T = bigy.shape[0] // N
+
+        n_time = (T - 1) if time_effects else 0
+        non_time = slice(0, self.k - n_time) if n_time > 0 else slice(None)
         
         y_mat = bigy.reshape((T, N))
         x_mat = bigx.reshape((T, N, self.k))
@@ -544,9 +567,7 @@ class PanelRE(RegressionPropsY, RegressionPropsVM):
         x_mean = x_mat.mean(axis=0)
 
         y_mean_long = np.tile(y_mean, T).reshape(-1, 1)
-        x_mean_long = np.zeros_like(bigx)
-        for i in range(self.k):
-            x_mean_long[:, i] = np.tile(x_mean[:, i], T)
+        x_mean_long = np.tile(x_mean, (T, 1))
 
         # Within Estimation
         y_dem = bigy - y_mean_long
@@ -573,17 +594,18 @@ class PanelRE(RegressionPropsY, RegressionPropsVM):
 
         # Between Estimation
         y_mean_col = y_mean.reshape(-1, 1)
-        xtx_b = x_mean.T @ x_mean
-        xty_b = x_mean.T @ y_mean_col
+        x_mean_nt = x_mean[:, non_time]
+        xtx_b = x_mean_nt.T @ x_mean_nt
+        xty_b = x_mean_nt.T @ y_mean_col
         
         try:
             beta_b = np.linalg.solve(xtx_b, xty_b)
         except np.linalg.LinAlgError:
             beta_b = np.linalg.pinv(xtx_b) @ xty_b
             
-        e_b = y_mean_col - (x_mean @ beta_b)
+        e_b = y_mean_col - (x_mean_nt @ beta_b)
         ssr_b = (e_b.T @ e_b)[0, 0]
-        sigma2_b = ssr_b / (N - self.k)
+        sigma2_b = ssr_b / (N - x_mean_nt.shape[1])
         
         self.sigma2_mu = sigma2_b - (self.sigma2_epsilon / T)
         
@@ -714,6 +736,9 @@ class GM_ErrorPooled(BaseGM_ErrorPooled):
                    If slx_lags>0, the specification becomes of the SLX type.
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                   
     nonspat_diag  : boolean
                    If True (default), then compute the 'LMC_RE' BSK test.
     maxit         : integer
@@ -826,6 +851,7 @@ class GM_ErrorPooled(BaseGM_ErrorPooled):
         w,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         nonspat_diag=True,
         max_iter=1,
         step1c=False,
@@ -839,10 +865,13 @@ class GM_ErrorPooled(BaseGM_ErrorPooled):
 
         self.title = "GMM POOLED SPATIAL ERROR MODEL (SEM)"
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=True)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
         self.k = bigx.shape[1]
-        
+  
+        if time_effects:
+            self.title += " WITH TIME EFFECTS"
+      
         BaseGM_ErrorPooled.__init__(self, bigy, bigx, w, max_iter=max_iter, step1c=step1c)
         
         self.name_ds = USER.set_name_ds(name_ds)
@@ -854,9 +883,10 @@ class GM_ErrorPooled(BaseGM_ErrorPooled):
         self.output['regime'], self.output['equation'] = (0, 0)
         self.other_top = _summary_iteration(self)
 
+        other_end = ""
         if nonspat_diag:
             self.bsk = BSK_tests(self, w, which=['LMC_RE'])
-            other_end = "\nDIAGNOSTIC TESTS\n"
+            other_end += "\nDIAGNOSTIC TESTS\n"
             other_end += f"{'-' * 84 }\n"
             other_end += "TEST                             DF        VALUE           PROB\n"
             for i in range(len(self.bsk)):
@@ -928,6 +958,9 @@ class ML_ErrorPooled(BaseML_ErrorPooled):
                    Default is 0.
     slx_vars     : string
                    List of variables to apply spatial lag to. Default is "all".
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                   
     nonspat_diag : boolean
                    If True (default), then compute the 'LMC_RE' BSK test.
     vm           : boolean
@@ -1035,6 +1068,7 @@ class ML_ErrorPooled(BaseML_ErrorPooled):
         epsilon=0.0000001,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         nonspat_diag=True,
         vm=False,
         name_y=None,
@@ -1045,18 +1079,18 @@ class ML_ErrorPooled(BaseML_ErrorPooled):
     ):
         self.title = "ML POOLED SPATIAL ERROR MODEL (SEM)"
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=True)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
+  
+        if time_effects:
+            self.title += " WITH TIME EFFECTS"
 
         self.k = bigx.shape[1]
         
         BaseML_ErrorPooled.__init__(self, bigy, bigx, w, method=method, epsilon=epsilon)
         
         self.name_ds = USER.set_name_ds(name_ds)
-        self.name_y = USER.set_name_y(name_y)
-        self.slx_lags = slx_lags
         self.name_w = USER.set_name_w(name_w, w)
-        
         self.name_x.append("lambda")
 
         self.output = pd.DataFrame(self.name_x, columns=['var_names'])
@@ -1067,9 +1101,10 @@ class ML_ErrorPooled(BaseML_ErrorPooled):
         self.schwarz = DIAG.schwarz(reg=self)
         self.other_top = _nonspat_top(self, ml=True)     
 
+        other_end = ""
         if nonspat_diag:
             self.bsk = BSK_tests(self, w, which=['LMC_RE'])
-            other_end = "\nDIAGNOSTIC TESTS\n"
+            other_end += "\nDIAGNOSTIC TESTS\n"
             other_end += f"{'-' * 84 }\n"
             other_end += "TEST                             DF        VALUE           PROB\n"
             for i in range(len(self.bsk)):
@@ -1327,7 +1362,10 @@ class GM_ErrorRE(BaseGM_ErrorRE, REGI.Regimes_Frame):
                    Number of spatial lags of X to include in the model specification.
                    If slx_lags>0, the specification becomes of the SLX type.
     slx_vars     : either "All" (default) or list of booleans to select x variables
-                   to be lagged                 
+                   to be lagged                
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                    
     full_weights: boolean
                   Considers different weights for each of the 6 moment
                   conditions if True or only 2 sets of weights for the
@@ -1439,6 +1477,7 @@ class GM_ErrorRE(BaseGM_ErrorRE, REGI.Regimes_Frame):
         w,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         full_weights=False,
         regimes=None,
         vm=False,
@@ -1451,9 +1490,12 @@ class GM_ErrorRE(BaseGM_ErrorRE, REGI.Regimes_Frame):
     ):
         self.title = "GMM SPATIAL ERROR PANEL MODEL - RANDOM EFFECTS (KKP)"
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=True)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
- 
+   
+        if time_effects:
+            self.title += " WITH TIME EFFECTS"
+
         if regimes is not None:
             raise NotImplementedError("Regimes are not currently implemented for GM_ErrorRE.")
             """
@@ -1483,7 +1525,7 @@ class GM_ErrorRE(BaseGM_ErrorRE, REGI.Regimes_Frame):
             regimes = True
         """
         self.output = pd.DataFrame(self.name_x, columns=['var_names'])
-        self.output['var_type'] = ['o'] + ['x'] * (kx-1) + ['wx'] * kwx + ["lambda", " sigma2_v", "sigma2_1"]
+        self.output['var_type'] = ['o'] + ['x'] * (kx-1) + ['wx'] * kwx + ["lambda", "sigma2_v", "sigma2_1"]
         self.output['regime'], self.output['equation'] = (0, 0)
         output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
 
@@ -1685,6 +1727,9 @@ class ML_ErrorFE(BaseML_ErrorFE):
                    If slx_lags>0, the specification becomes of the SLX type.
     slx_vars     : either "All" (default) or list of booleans to select x variables
                    to be lagged                   
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                   
     epsilon      : float
                    tolerance criterion in mimimize_scalar function and
                    inverse_product
@@ -1765,7 +1810,9 @@ class ML_ErrorFE(BaseML_ErrorFE):
     mean_mu_i    : float
                    Mean of the fixed effects (mu_i) across all observations
     mu_i         : array
-                   nx1 array of the fixed effects (mu_i) for each observation
+                   nx1 array of the individual fixed effects
+    fixed_effects: array
+                   alias for mu_i (same object)
 
     Examples
     --------
@@ -1823,6 +1870,7 @@ class ML_ErrorFE(BaseML_ErrorFE):
         w,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         epsilon=0.0000001,
         vm=False,
         name_y=None,
@@ -1834,8 +1882,15 @@ class ML_ErrorFE(BaseML_ErrorFE):
 
         self.title = "ML SPATIAL ERROR PANEL MODEL - FIXED EFFECTS"
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=False)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=False)
         any(set_warn(self, i) for i in warn)
+  
+        if time_effects:
+            self.title += " WITH TIME EFFECTS"
+
+        N = w.n
+        dem_x = demean_panel(bigx, N, self.t, phi=0)
+        time_inv_check(dem_x, self.name_x)
 
         BaseML_ErrorFE.__init__(self, bigy, bigx, w, epsilon=epsilon)
 
@@ -1844,7 +1899,7 @@ class ML_ErrorFE(BaseML_ErrorFE):
         self.name_w = USER.set_name_w(name_w, w)
 
         self.output = pd.DataFrame(self.name_x, columns=['var_names'])
-        self.output['var_type'] = ['o'] + ['x'] * (kx-1) + ['wx'] * kwx + ["lambda"]
+        self.output['var_type'] = ['x'] * kx + ['wx'] * kwx + ["lambda"]
         self.output['regime'], self.output['equation'] = (0, 0)
 
         self.aic = DIAG.akaike(reg=self)
@@ -1852,11 +1907,14 @@ class ML_ErrorFE(BaseML_ErrorFE):
         self.other_top = _nonspat_top(self, ml=True)      
 
         u_undemean = bigy - np.dot(bigx, self.betas[:-1])
-        self.mu_i = u_undemean.reshape(self.t, w.n).mean(axis=0).reshape(-1, 1)        
+        self.mu_i = u_undemean.reshape(self.t, w.n).mean(axis=0).reshape(-1, 1) 
+        self.fixed_effects = self.mu_i
         self.mean_mu_i = self.mu_i.mean()
         self.other_top += "%-20s:%12.4f\n" % (
-            "Fixed-effects mean", self.mean_mu_i)
+            "Individual FE mean", self.mean_mu_i)
         output(reg=self, vm=vm, robust=False, other_end=False, latex=latex)
+
+# PAREI A REVISAO DE 2-WAY AQUI! #
 
 class BaseML_ErrorRE(RegressionPropsY, RegressionPropsVM):
 
@@ -2135,7 +2193,10 @@ class ML_ErrorRE(BaseML_ErrorRE):
                    Number of spatial lags of X to include in the model specification.
                    If slx_lags>0, the specification becomes of the SLX type.
     slx_vars     : either "All" (default) or list of booleans to select x variables
-                   to be lagged                   
+                   to be lagged            
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                          
     epsilon      : float
                    tolerance criterion in mimimize_scalar function and
                    inverse_product
@@ -2274,6 +2335,7 @@ class ML_ErrorRE(BaseML_ErrorRE):
         w,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         epsilon=0.0000001,
         vm=False,
         name_y=None,
@@ -2284,9 +2346,12 @@ class ML_ErrorRE(BaseML_ErrorRE):
     ):
         self.title = "ML SPATIAL ERROR PANEL MODEL (SEM) - RANDOM EFFECTS"
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=True)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
-
+  
+        if time_effects:
+            self.title += " WITH TIME EFFECTS"
+            
         BaseML_ErrorRE.__init__(self, bigy, bigx, w, epsilon=epsilon)
         self.name_ds = USER.set_name_ds(name_ds)
         self.name_x.extend(["lambda", "sigma2_u"])
@@ -2440,7 +2505,7 @@ class BaseML_LagFE(RegressionPropsY, RegressionPropsVM):
         wTwpredy = spdot(waiTwai_nt, xb)
         wpyTwpy = spdot(xb.T, wTwpredy)
 
-        # order of variables is beta, rho, sigma2
+        # order of variables is beta, rho, phi, sigma2
         v1 = np.vstack((xtx / self.sig2, xTwpy.T / self.sig2, np.zeros((1, self.k))))
         v2 = np.vstack(
             (
@@ -2498,7 +2563,10 @@ class ML_LagFE(BaseML_LagFE):
                    Number of spatial lags of X to include in the model specification.
                    If slx_lags>0, the specification becomes of the SLX type.
     slx_vars     : either "All" (default) or list of booleans to select x variables
-                   to be lagged                   
+                   to be lagged    
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                                  
     epsilon      : float
                    tolerance criterion in mimimize_scalar function and
                    inverse_product
@@ -2589,7 +2657,9 @@ class ML_LagFE(BaseML_LagFE):
     mean_mu_i    : float
                    Mean of the fixed effects (mu_i) across observations
     mu_i         : array
-                   nx1 array of the fixed effects (mu_i) for each observation
+                   nx1 array of the individual fixed effects
+    fixed_effects: array
+                   alias for mu_i (same object)
                    
     Examples
     --------
@@ -2647,6 +2717,7 @@ class ML_LagFE(BaseML_LagFE):
         w,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         epsilon=0.0000001,
         spat_impacts="simple",        
         vm=False,
@@ -2659,8 +2730,15 @@ class ML_LagFE(BaseML_LagFE):
         self.title = "ML SPATIAL LAG PANEL - FIXED EFFECTS"
 
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=False)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=False)
         any(set_warn(self, i) for i in warn)
+  
+        if time_effects:
+            self.title += " WITH TIME EFFECTS"  
+
+        N = w.n
+        dem_x = demean_panel(bigx, N, self.t, phi=0)
+        time_inv_check(dem_x, self.name_x)
 
         BaseML_LagFE.__init__(self, bigy, bigx, w, epsilon=epsilon)
 
@@ -2677,11 +2755,16 @@ class ML_LagFE(BaseML_LagFE):
         self.other_top, self.other_mid, other_end = ("", "", "")
         self.other_top += _nonspat_top(self, ml=True)
 
-        u_undemean = bigy - np.dot(bigx, self.betas[:-1])
-        self.mu_i = u_undemean.reshape(self.t, w.n).mean(axis=0).reshape(-1, 1)
-        self.mean_mu_i = self.mu_i.mean()
+        y_mean = bigy.reshape(self.t, N).mean(axis=0).reshape(-1, 1)
+        x_mean = bigx.reshape(self.t, N, bigx.shape[1]).mean(axis=0)
+        W_y_mean = w.sparse @ y_mean
+
+        self.mu_i = y_mean - (x_mean @ self.betas[:-1]) - self.rho * W_y_mean
+        self.mean_mu_i = float(self.mu_i.mean())
+        self.fixed_effects = self.mu_i
+
         self.other_top += "%-20s:%12.4f\n" % (
-            "Fixed-effects mean", self.mean_mu_i)        
+            "Individual FE mean", self.mean_mu_i)        
         if spat_impacts:
             self.sp_multipliers, impacts_str = _summary_impacts(self, w, spat_impacts, slx_lags,slx_vars)
             other_end += impacts_str
@@ -2889,9 +2972,37 @@ class BaseML_LagRE(RegressionPropsY, RegressionPropsVM):
         self.vm1 = la.inv(v)  # vm1 includes variance for sigma2
         self.vm = self.vm1[:-1, :-1]  # vm is for coefficients and phi
         self.varb = la.inv(np.hstack((v1[:-2], v2[:-2])))
-        self.k += 1 # add one to k to account for rho
+        self.k += 2 # add two to k to account for rho and phi
         self.n = NT
 
+
+    def lag_c_loglik_sp(self, rho, n, t, e0, e1, I, Wsp):
+        # concentrated log-lik for lag model, sparse algebra
+        if isinstance(rho, np.ndarray):
+            if rho.shape == (1, 1):
+                rho = rho[0][0]
+        er = e0 - rho * e1
+        sig2 = spdot(er.T, er) / (n * t)
+        nlsig2 = (n * t / 2.0) * np.log(sig2)
+        a = I - rho * Wsp
+        LU = sps.linalg.splu(a.tocsc())
+        jacob = t * np.sum(np.log(np.abs(LU.U.diagonal())))
+        clike = nlsig2 - jacob
+        return clike
+
+
+    def phi_c_loglik(self, phi, rho, beta, bigy, bigx, n, t, W_nt):
+        # Demeaned variables
+        y = demean_panel(bigy, n, t, phi=phi)
+        x = demean_panel(bigx, n, t, phi=phi)
+        # Lag dependent variable
+        ylag = spdot(W_nt, y)
+        er = y - rho * ylag - spdot(x, beta)
+        sig2 = spdot(er.T, er)
+        nlsig2 = (n * t / 2.0) * np.log(sig2)
+        nphi2 = (n / 2.0) * np.log(phi ** 2)
+        clike = nlsig2 - nphi2
+        return clike
 
 class ML_LagRE(BaseML_LagRE):
 
@@ -2908,6 +3019,14 @@ class ML_LagRE(BaseML_LagRE):
                    variables, excluding the constant
     w            : pysal W object
                    Spatial weights object
+    slx_lags     : integer
+                   Number of spatial lags of X to include in the model specification.
+                   If slx_lags>0, the specification becomes of the SLX type.
+    slx_vars     : either "All" (default) or list of booleans to select x variables
+                   to be lagged    
+    time_effects : boolean
+                   If True, then include time dummies in the model specification (first ommitted).
+                   Default: False                   
     spat_impacts : string or list
                    Include average direct impact (ADI), average indirect impact (AII),
                     and average total impact (ATI) in summary results.
@@ -3048,6 +3167,7 @@ class ML_LagRE(BaseML_LagRE):
         w,
         slx_lags=0,
         slx_vars="all",
+        time_effects=False,
         epsilon=0.0000001,
         spat_impacts="simple",        
         vm=False,
@@ -3061,8 +3181,11 @@ class ML_LagRE(BaseML_LagRE):
         self.title = "ML SPATIAL LAG PANEL - RANDOM EFFECTS"
 
         bigy, bigx, self.name_y, self.name_x, w, warn, self.slx_lags, self.title, kx, kwx, self.t = prepare_panel(
-            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, add_constant=True)
+            y, x, w, name_y, name_x, slx_lags, slx_vars, self.title, time_effects, add_constant=True)
         any(set_warn(self, i) for i in warn)
+  
+        if time_effects:
+            self.title += " WITH TIME EFFECTS"
 
         BaseML_LagRE.__init__(self, bigy, bigx, w, epsilon=epsilon)
 
@@ -3082,34 +3205,3 @@ class ML_LagRE(BaseML_LagRE):
             self.sp_multipliers, impacts_str = _summary_impacts(self, w, spat_impacts, slx_lags,slx_vars)
             other_end += impacts_str
         output(reg=self, vm=vm, other_end=other_end, latex=latex)
-
-
-    def lag_c_loglik_sp(self, rho, n, t, e0, e1, I, Wsp):
-        # concentrated log-lik for lag model, sparse algebra
-        if isinstance(rho, np.ndarray):
-            if rho.shape == (1, 1):
-                rho = rho[0][0]
-        er = e0 - rho * e1
-        sig2 = spdot(er.T, er) / (n * t)
-        nlsig2 = (n * t / 2.0) * np.log(sig2)
-        a = I - rho * Wsp
-        LU = sps.linalg.splu(a.tocsc())
-        jacob = t * np.sum(np.log(np.abs(LU.U.diagonal())))
-        clike = nlsig2 - jacob
-        return clike
-
-
-    def phi_c_loglik(self, phi, rho, beta, bigy, bigx, n, t, W_nt):
-        # Demeaned variables
-        y = demean_panel(bigy, n, t, phi=phi)
-        x = demean_panel(bigx, n, t, phi=phi)
-        # Lag dependent variable
-        ylag = spdot(W_nt, y)
-        er = y - rho * ylag - spdot(x, beta)
-        sig2 = spdot(er.T, er)
-        nlsig2 = (n * t / 2.0) * np.log(sig2)
-        nphi2 = (n / 2.0) * np.log(phi ** 2)
-        clike = nlsig2 - nphi2
-        return clike
-
-

--- a/spreg/panel_utils.py
+++ b/spreg/panel_utils.py
@@ -32,23 +32,42 @@ def prepare_panel(y, x, w, name_y, name_x, slx_lags, slx_vars, title, time_effec
     name_y = USER.set_name_y(name_y)
 
     w = USER.check_weights(w, bigy, w_required=True, time=True, slx_lags=slx_lags)
-    kx = bigx.shape[1]
 
-    if slx_lags >0:
-        title += " WITH SLX"
-        bigx,name_x = USER.flex_wx(w,x=bigx,name_x=name_x,constant=add_constant,
-                                        slx_lags=slx_lags,slx_vars=slx_vars, panel=True)            
-    kwx = bigx.shape[1] - kx
-
+    kt = 0
     if time_effects and T > 1:
         n = w.n
-        time_dummies = np.repeat(np.eye(T), n, axis=0)[:, 1:]        
-        bigx = np.hstack((bigx, time_dummies))            
+        time_dummies = np.repeat(np.eye(T), n, axis=0)[:, 1:]
         time_names = [f"time_{t}" for t in range(2, T + 1)]
-        name_x.extend(time_names)
-        kx += T - 1
+        bigx = np.hstack((bigx, time_dummies))
+        name_x = list(name_x) + time_names
+        kt = T - 1
 
-    return bigy, bigx, name_y, name_x, w, warn, slx_lags, title, kx, kwx, T
+    if slx_lags > 0 and kt > 0:
+        n_work = bigx.shape[1] - (1 if add_constant else 0)  # non-constant cols
+        n_orig = n_work - kt
+        if isinstance(slx_vars, str) and slx_vars.lower() == "all":
+            slx_vars = [True] * n_orig + [False] * kt
+        elif isinstance(slx_vars, list):
+            if len(slx_vars) != n_orig:
+                raise ValueError(
+                    f"slx_vars length ({len(slx_vars)}) must equal the number of "
+                    f"exogenous variables excluding constant and time effects ({n_orig})."
+                )
+            slx_vars = list(slx_vars) + [False] * kt
+        else:
+            raise ValueError("slx_vars must be 'all' or a list of booleans.")
+
+    kx = bigx.shape[1]
+
+    if slx_lags > 0:
+        title += " WITH SLX"
+        bigx, name_x = USER.flex_wx(
+            w, x=bigx, name_x=name_x, constant=add_constant,
+            slx_lags=slx_lags, slx_vars=slx_vars, panel=True,
+        )
+    kwx = bigx.shape[1] - kx
+
+    return bigy, bigx, name_y, name_x, w, warn, slx_lags, slx_vars, title, kx, kwx, T
 
 def check_panel(y, x, w, name_y, name_x):
     """
@@ -166,8 +185,6 @@ def demean_panel(arr, n, t, phi=0):
     arr_dm = spdot(Q, arr)
 
     return arr_dm
-
-import numpy as np
 
 def time_inv_check(dem_x, name_x):
     """

--- a/spreg/panel_utils.py
+++ b/spreg/panel_utils.py
@@ -12,7 +12,7 @@ from scipy import sparse as sp
 from .sputils import spdot
 from . import user_output as USER
 
-def prepare_panel(y, x, w, name_y, name_x, slx_lags, slx_vars, title, add_constant=True):
+def prepare_panel(y, x, w, name_y, name_x, slx_lags, slx_vars, title, time_effects, add_constant=True):
     """
     Prepare the data for panel regression.
     Parameters as in the panel regression classes, with the addition of:
@@ -39,6 +39,15 @@ def prepare_panel(y, x, w, name_y, name_x, slx_lags, slx_vars, title, add_consta
         bigx,name_x = USER.flex_wx(w,x=bigx,name_x=name_x,constant=add_constant,
                                         slx_lags=slx_lags,slx_vars=slx_vars, panel=True)            
     kwx = bigx.shape[1] - kx
+
+    if time_effects and T > 1:
+        n = w.n
+        time_dummies = np.repeat(np.eye(T), n, axis=0)[:, 1:]        
+        bigx = np.hstack((bigx, time_dummies))            
+        time_names = [f"time_{t}" for t in range(2, T + 1)]
+        name_x.extend(time_names)
+        kx += T - 1
+
     return bigy, bigx, name_y, name_x, w, warn, slx_lags, title, kx, kwx, T
 
 def check_panel(y, x, w, name_y, name_x):
@@ -157,3 +166,32 @@ def demean_panel(arr, n, t, phi=0):
     arr_dm = spdot(Q, arr)
 
     return arr_dm
+
+import numpy as np
+
+def time_inv_check(dem_x, name_x):
+    """
+    Check for time-invariant variables in a demeaned matrix.
+    
+    Parameters
+    ----------
+    dem_x  : array
+             Demeaned independent variables array (n*t x k)
+    name_x : list of strings
+             Names of independent variables
+             
+    Raises
+    ------
+    ValueError
+        If time-invariant variables are detected (variance is zero).
+    """
+    var_check = np.var(dem_x, axis=0)
+    invalid_cols = np.where(var_check <= 1e-12)[0]
+    
+    if invalid_cols.size > 0:
+        invalid_names = [name_x[i] for i in invalid_cols]
+        raise ValueError(
+            f"Time-invariant variables detected: {', '.join(invalid_names)}. "
+            "These cannot be estimated using the Within transformation. "
+            "Please remove them from the input variables (x)."
+        )

--- a/spreg/tests/test_diagnostics_panel.py
+++ b/spreg/tests/test_diagnostics_panel.py
@@ -1,44 +1,27 @@
 import unittest
 import libpysal
 import numpy as np
-import pandas as pd
+import geopandas as gpd
 from spreg.diagnostics_panel import panel_LMlag, panel_LMerror, panel_rLMlag
 from spreg.diagnostics_panel import panel_rLMerror, panel_Hausman
-from spreg.panel_fe import Panel_FE_Lag, Panel_FE_Error
-from spreg.panel_re import Panel_RE_Lag, Panel_RE_Error
+from spreg.panel_fe import Panel_FE_Lag
+from spreg.panel_re import Panel_RE_Lag
 from libpysal.common import RTOL
-from libpysal.weights import w_subset
-
 
 class Test_Panel_Diagnostics(unittest.TestCase):
     def setUp(self):
         self.ds_name = "NCOVR"
-        nat = libpysal.examples.load_example(self.ds_name)
-        self.db = libpysal.io.open(nat.get_path("NAT.dbf"), "r")
-        nat_shp = libpysal.examples.get_path("NAT.shp")
-        w_full = libpysal.weights.Queen.from_shapefile(nat_shp)
-        self.y_name = ["HR70", "HR80", "HR90"]
-        self.x_names = ["RD70", "RD80", "RD90", "PS70", "PS80", "PS90"]
-        c_names = ["STATE_NAME", "FIPSNO"]
-        y_full = [self.db.by_col(name) for name in self.y_name]
-        y_full = np.array(y_full).T
-        x_full = [self.db.by_col(name) for name in self.x_names]
-        x_full = np.array(x_full).T
-        c_full = [self.db.by_col(name) for name in c_names]
-        c_full = pd.DataFrame(c_full, index=c_names).T
+        libpysal.examples.load_example(self.ds_name)
+
+        db = gpd.read_file(libpysal.examples.get_path("NAT.shp"))
         filter_states = ["Kansas", "Missouri", "Oklahoma", "Arkansas"]
-        filter_counties = c_full[c_full["STATE_NAME"].isin(filter_states)]
-        filter_counties = filter_counties["FIPSNO"].values
-        counties = np.array(self.db.by_col("FIPSNO"))
-        subid = np.where(np.isin(counties, filter_counties))[0]
-        self.w = w_subset(w_full, subid)
+        db = db[db["STATE_NAME"].isin(filter_states)].copy()
+
+        self.y = db[["HR70", "HR80", "HR90"]]
+        self.x = db[["RD70", "RD80", "RD90", "PS70", "PS80", "PS90"]]
+
+        self.w = libpysal.weights.Queen.from_dataframe(db, use_index=True)
         self.w.transform = "r"
-        self.y = y_full[
-            subid,
-        ]
-        self.x = x_full[
-            subid,
-        ]
 
     def test_LM(self):
         lmlag = panel_LMlag(self.y, self.x, self.w)

--- a/spreg/tests/test_panel.py
+++ b/spreg/tests/test_panel.py
@@ -48,7 +48,7 @@ class TestPanel(unittest.TestCase):
         expected_betas = np.array([[ 0.505371, -8.026947]]) 
         np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
         
-        expected_vm = np.array([0.180367, 1.539671])
+        expected_vm = np.array([0.180595, 1.541625])
         np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
 
         expected_mean_mu_i = 12.938448
@@ -177,7 +177,7 @@ class TestPanel(unittest.TestCase):
         np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
 
         other = [model.aic, model.schwarz, model.logll, model.mean_mu_i]
-        expected_other = [ 1.322196e+04,  1.323927e+04, -6.607981e+03,  1.244338e+01]
+        expected_other = [ 1.322196e+04,  1.323927e+04, -6.607981e+03,  1.074278e+01]
         np.testing.assert_allclose(other, expected_other, rtol=1e-4)
 
         multipliers = [1.     , 0.23917, 1.23917]
@@ -211,5 +211,183 @@ class TestPanel(unittest.TestCase):
         expected_impact_out = "PS         1.1955          0.6667          1.8622"
         self.assertIn(expected_impact_out, impact_out)
 
+    def test_PooledOLS_twoway(self):
+        model = PANEL.PooledOLS(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            nonspat_diag=False,
+            spat_diag=True,
+            BSK_list='all',
+        )
+        expected_betas = np.array([[7.800349, 4.781756, 1.314681, -0.885384, -0.273779]])
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array([0.053031, 0.018057, 0.022965, 0.088968, 0.089289])
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        expected_bsk = [13.665972, 19.766431, 577.470591, 11.391972, 7.786688]
+        np.testing.assert_allclose(
+            [i for i in model.bsk['Statistic']], expected_bsk, rtol=1e-4
+        )
+
+    def test_PanelFE_twoway(self):
+        model = PANEL.PanelFE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array([[0.459332, -7.763154, -0.720306, -0.61024]])
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array([0.190276, 1.541609, 0.060306, 0.063254])
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        expected_mean_mu_i = 13.251921
+        np.testing.assert_allclose(model.mean_mu_i, expected_mean_mu_i, rtol=1e-4)
+
+    def test_PanelRE_twoway(self):
+        model = PANEL.PanelRE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array([[7.963289, 4.482333, 1.111048, -0.87882, -0.311604]])
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array([0.058266, 0.02678, 0.036517, 0.062459, 0.062936])
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        other = [model.sigma2_mu, model.sigma2_epsilon, model.theta, model.hausman_stat]
+        expected_other = [10.357834, 23.661136, 0.342514, 104.883775]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-4)
+
+    def test_GM_ErrorPooled_twoway(self):
+        model = PANEL.GM_ErrorPooled(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array(
+            [[7.925487, 4.528931, 1.066654, -0.882939, -0.277609, 0.499603]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array([0.271308, 0.048313, 0.052779, 0.325504, 0.337523, 0.000795])
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+
+    def test_ML_ErrorPooled_twoway(self):
+        model = PANEL.ML_ErrorPooled(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array(
+            [[7.927721, 4.52292, 1.060391, -0.88297, -0.277157, 0.450746]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array([0.133564, 0.024178, 0.027279, 0.247709, 0.248142, 0.000615])
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        other = [model.aic, model.schwarz, model.logll]
+        expected_other = [14840.680075, 14869.526968, -7415.340037]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-4)
+
+    def test_GM_ErrorRE_twoway(self):
+        model = PANEL.GM_ErrorRE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array(
+            [[8.009469, 4.338729, 0.982888, -0.879355, -0.302579, 0.434806, 23.83305, 41.442461]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array([0.131209, 0.031242, 0.037627, 0.189276, 0.189836])
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+
+    def test_ML_ErrorFE_twoway(self):
+        model = PANEL.ML_ErrorFE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array(
+            [[0.575023, -7.500393, -0.731785, -0.59552, 0.184641]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [1.368967e-01, 1.174591e+00, 5.896025e-02, 6.106609e-02, 8.940684e-04]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        other = [model.aic, model.schwarz, model.logll, model.mean_mu_i]
+        expected_other = [13214.080401, 13237.157916, -6603.040201, 13.096164]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-4)
+
+    def test_ML_ErrorRE_twoway(self):
+        model = PANEL.ML_ErrorRE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array(
+            [[7.975858, 4.402556, 1.064028, -0.881005, -0.29602, 0.434449, 6.074556]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-3)
+        expected_vm = np.array(
+            [1.160089e-01, 2.918016e-02, 3.589305e-02, 1.902962e-01, 1.908026e-01, 2.556006e-05, 1.350158e-03]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-3)
+        other = [model.logll, model.phi]
+        expected_other = [-7443.594837, 0.253001]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-3)
+
+    def test_ML_LagFE_twoway(self):
+        model = PANEL.ML_LagFE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array(
+            [[0.507792, -6.926939, -0.586646, -0.447572, 0.180828]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [1.239681e-01, 1.019751e+00, 3.981681e-02, 4.176785e-02, 8.715624e-04]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        other = [model.aic, model.schwarz, model.logll, model.mean_mu_i]
+        expected_other = [13216.599418, 13245.446311, -6603.299709, 11.117378]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-4)
+        multipliers = [1.0, 0.220745, 1.220745]
+        np.testing.assert_allclose(
+            model.sp_multipliers['simple'], multipliers, atol=1e-4
+        )
+
+    def test_ML_LagRE_twoway(self):
+        model = PANEL.ML_LagRE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+        )
+        expected_betas = np.array(
+            [[4.756492, 3.607342, 1.203576, -0.585533, -0.085171, 0.354285, 0.740364]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-3)
+        expected_vm = np.array(
+            [0.09327, 0.02648, 0.028083, 0.060859, 0.060958, 0.000578, 0.000453]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-3)
+        other = [model.aic, model.schwarz, model.logll]
+        expected_other = [14773.984357, 14814.370007, -7379.992179]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-3)
+        multipliers = [1.0, 0.54867, 1.54867]
+        np.testing.assert_allclose(
+            model.sp_multipliers['simple'], multipliers, atol=1e-3
+        )
+
+    
 if __name__ == "__main__":
     unittest.main()

--- a/spreg/tests/test_panel.py
+++ b/spreg/tests/test_panel.py
@@ -388,6 +388,211 @@ class TestPanel(unittest.TestCase):
             model.sp_multipliers['simple'], multipliers, atol=1e-3
         )
 
-    
+    def test_PooledOLS_twoway_slx(self):
+        model = PANEL.PooledOLS(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+            nonspat_diag=False,
+            spat_diag=False,
+        )
+        expected_betas = np.array(
+            [[7.459689, 4.376823, 1.127946, -0.899773, -0.216858, 0.868972, 0.705451]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [0.063186, 0.039154, 0.040512, 0.088524, 0.089082, 0.062592, 0.081522]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+
+    def test_PanelFE_twoway_slx(self):
+        model = PANEL.PanelFE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[0.674627, -7.162413, -0.697255, -0.652331, -0.725542, -1.57907]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [0.241828, 2.492844, 0.060997, 0.068755, 0.589885, 4.761883]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        expected_mean_mu_i = 13.835659
+        np.testing.assert_allclose(model.mean_mu_i, expected_mean_mu_i, rtol=1e-4)
+
+    def test_PanelRE_twoway_slx(self):
+        model = PANEL.PanelRE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[7.651553, 4.021632, 1.021444, -0.892232, -0.248262, 0.942791, 0.546]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [0.074437, 0.053998, 0.064889, 0.062181, 0.063033, 0.089954, 0.129911]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        other = [model.sigma2_mu, model.sigma2_epsilon, model.theta, model.hausman_stat]
+        expected_other = [10.399289, 23.676399, 0.343139, 103.475028]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-4)
+
+    def test_GM_ErrorPooled_twoway_slx(self):
+        model = PANEL.GM_ErrorPooled(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[7.444685, 4.520406, 1.002456, -0.903187, -0.224908, 0.534491, 0.825905, 0.492934]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [0.290198, 0.065433, 0.048363, 0.316966, 0.325087, 0.075384, 0.106246, 0.00081]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+
+    def test_ML_ErrorPooled_twoway_slx(self):
+        model = PANEL.ML_ErrorPooled(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[7.44439, 4.521167, 1.000437, -0.903285, -0.225176, 0.526606, 0.827264, 0.44654]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [0.16113, 0.028954, 0.031241, 0.243432, 0.244714, 0.072921, 0.098265, 0.000619]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        other = [model.aic, model.schwarz, model.logll]
+        expected_other = [14836.904221, 14877.289871, -7411.45211]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-4)
+
+    def test_GM_ErrorRE_twoway_slx(self):
+        model = PANEL.GM_ErrorRE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[7.546107, 4.293166, 0.946042, -0.899351, -0.240526, 0.613014, 0.753564, 0.430928, 23.683704, 41.485409]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [0.168958, 0.037395, 0.043779, 0.18615, 0.187817, 0.095167, 0.134424]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+
+    def test_ML_ErrorFE_twoway_slx(self):
+        model = PANEL.ML_ErrorFE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[0.674047, -7.136074, -0.708363, -0.628613, -0.568084, -1.391175, 0.183251]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [1.501966e-01, 1.519799e+00, 5.942544e-02, 6.644126e-02, 4.388733e-01, 3.387919e+00, 8.953020e-04]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        other = [model.aic, model.schwarz, model.logll, model.mean_mu_i]
+        expected_other = [13217.19551, 13251.811781, -6602.597755, 13.698298]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-4)
+
+    def test_ML_ErrorRE_twoway_slx(self):
+        model = PANEL.ML_ErrorRE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[7.507443, 4.232198, 0.994743, -0.902304, -0.219382, 0.811176, 0.772035, 0.432543, 6.051531]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-3)
+        expected_vm = np.array(
+            [1.438760e-01, 3.950852e-02, 4.639000e-02, 1.884604e-01, 1.897577e-01, 8.751699e-02, 1.246807e-01, 2.587219e-05, 1.340475e-03]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-3)
+        other = [model.logll, model.phi]
+        expected_other = [-7439.046097, 0.252864]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-3)
+
+    def test_ML_LagFE_twoway_slx(self):
+        model = PANEL.ML_LagFE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[0.713026, -7.036564, -0.575711, -0.519863, -0.698457, -0.055027, 0.183518]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-4)
+        expected_vm = np.array(
+            [1.572995e-01, 1.621448e+00, 4.012282e-02, 4.506673e-02, 3.837365e-01, 3.154243e+00, 8.948976e-04]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-4)
+        other = [model.aic, model.schwarz, model.logll, model.mean_mu_i]
+        expected_other = [13218.991327, 13259.376977, -6602.495663, 11.262956]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-4)
+        multipliers = [1.0, 0.224767, 1.224767]
+        np.testing.assert_allclose(
+            model.sp_multipliers['simple'], multipliers, atol=1e-4
+        )
+        impact_out = model.summary[-270:-220]
+        expected_impact_out = "PS        -7.0366         -1.6490         -8.6855\n"
+        self.assertIn(expected_impact_out, impact_out)
+
+    def test_ML_LagRE_twoway_slx(self):
+        model = PANEL.ML_LagRE(
+            self.y,
+            self.x,
+            w=self.w,
+            time_effects=True,
+            slx_lags=1,
+        )
+        expected_betas = np.array(
+            [[4.467153, 4.170904, 0.934329, -0.540667, -0.126389, -1.098932, 0.156781, 0.400599, 0.760345]]
+        )
+        np.testing.assert_allclose(model.betas.T, expected_betas, atol=1e-3)
+        expected_vm = np.array(
+            [0.098409, 0.042185, 0.047579, 0.061178, 0.061308, 0.084525, 0.096859, 0.000672, 0.000469]
+        )
+        np.testing.assert_allclose(model.vm.diagonal(), expected_vm, atol=1e-3)
+        other = [model.aic, model.schwarz, model.logll]
+        expected_other = [14761.496453, 14813.420861, -7371.748227]
+        np.testing.assert_allclose(other, expected_other, rtol=1e-3)
+        multipliers = [1.0, 0.668331, 1.668331]
+        np.testing.assert_allclose(
+            model.sp_multipliers['simple'], multipliers, atol=1e-3
+        )
+        impact_out = model.summary[-270:-220]
+        expected_impact_out = "PS         0.9343          0.8860          1.8203\n"
+        self.assertIn(expected_impact_out, impact_out)
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR extends spreg’s spatial panel estimators to support two-way specifications (time_effects=True: individual + time effects). The notebook with examples has been updated to include the additional specifications.